### PR TITLE
Fix : cat new .gitconfig to existing instead of overwrite

### DIFF
--- a/modules/cleanup.sh
+++ b/modules/cleanup.sh
@@ -4,5 +4,5 @@
 
 # copy a basic .gitconfig if we have it...
 if [ -f "$THISPATH/support/.gitconfig" ] ; then
-  cp $THISPATH/support/.gitconfig ~/.gitconfig
+  cat $THISPATH/support/.gitconfig >> ~/.gitconfig
 fi


### PR DESCRIPTION
If there was an existing .gitconfig (maybe setup to get Github access before running this script for example) then it would be overwritten. This commit changes that to simply append to any existing.