### PR TITLE
fix issue #10

### DIFF
--- a/modules/packages.sh
+++ b/modules/packages.sh
@@ -7,7 +7,7 @@ sudo apt install -y build-essential gettext libssl-dev libreadline-dev \
                     zlib1g-dev sqlite3 libsqlite3-dev libbz2-dev \
                     libxml2-dev libdb-dev ccache libffi-dev libpq-dev mcrypt \
                     liblzma-dev lzma libncurses5-dev xz-utils libxmlsec1-dev \
-                    tk-dev llvm libicu-dev libcurl4-openssl-dev
+                    tk-dev llvm libicu-dev libcurl4-openssl-dev checkinstall
 
 # install some 'nice to have' that are missing from very mininal images...
 sudo apt install -y nano htop openssh-server openssh-client

--- a/support/.gitconfig
+++ b/support/.gitconfig
@@ -14,3 +14,6 @@
 [core]
         autocrlf = false
         filemode = false
+        pager = less -FRX
+[diff]
+        colorMoved = zebra


### PR DESCRIPTION
Fix the issue on Ubuntu 22.04 (and perhaps other systems with the newer OpenSSL) that causes Ruby versions < 3.1 to fail to install.

Closes #10 