### PR TITLE
Update tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Debian-based distribution. Note that the script will only run on debian-based
 distributions (Debian, Ubuntu, Kali, Mint etc etc)
 
 **Note that the script is geared towards and tested on _server_ versions more
-than Desktop ones, though it has been used successfully on both.**
+than Desktop ones, though it has been used successfully on both**. In fact my
+primary day-to-day machine runs Ubuntu Desktop (22.04) which was set up using
+this script.
 
 ## Prerequisites
 
@@ -77,10 +79,9 @@ The script works on a bare newly installed system and provides the following fun
   [`Perlbrew`][perlbrew] with cpan and cpanm pre-installed and configured.
   Several PERL modules that make cpan easier are also pre-installed
 * Enable resolution of WINS hostnames
-* Install Nginx web server(Latest), PHP(v7.4) and Postgresql database(v12) ( all
-  3 disabled by default). I am planning (soon) to upgrade PHP and Postgresql
-  to more modern versions soon, though both these versions are currently (June
-  2022) at least still supported with security fixes.
+* Install Nginx web server(Latest), PHP(v7.4 & 8.1) and Postgresql database(v14)
+  (all 3 disabled by default). The default php cli version is explicitly set to
+  7.4 for the moment however.
 * Install Docker and Docker-compose (disabled by default)
 
 ## Security
@@ -94,11 +95,10 @@ with this script.
 
 ## Current Issues/Bugs
 
-### Installing Ruby versions < 3.1 fails on Ubuntu 22.04
-
-Issue [#10][issue-10]. The OpenSSL version in Ubuntu 22.04 is incompatible with any ruby
-below version 3 and causes installation errors. There is a work-around
-[here][issue-10-workaround] which I will shortly add to the script.
+* Pyenv, Rbenv, NVM and Perlbrew are only setup for the `Bash` Shell. If you are
+  using another (eg `Zsh`) you will need to copy over the required setup commmands
+  from the `.bashrc` file to the correct file. I'm looking at auto-detecting the
+  running shell and choosing the correct config however.
 
 ## Usage
 

--- a/modules/docker.sh
+++ b/modules/docker.sh
@@ -4,16 +4,10 @@
 
 # DONT DO ANY OF THIS IN WSL (Windows Subsystem for Linux)!
 if [ ! $os = "wsl" ]; then
-  # docker
-  sudo apt install -y docker-ce docker-ce-cli containerd.io
+  # docker. We no longer use the old V1 of docker compuse, we install v2.
+  sudo apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
   # remove the need for sudo...
   sudo usermod -aG docker $USER
-
-  # docker-compose
-  # We install the v1.x branch here, V2 is in BETA and quite stable it seems, so
-  # will probably move over to that in the future
-  sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  sudo chmod +x /usr/local/bin/docker-compose
 else
   echo
   echo " -<[ Skipping Docker in WSL ]>- "

--- a/modules/nginx-php-pgsql.sh
+++ b/modules/nginx-php-pgsql.sh
@@ -4,11 +4,22 @@
 
 # we already installed all the required ppa's etc in the packages/updates so
 # lets just install
-
 sudo apt install -y nginx nginx-extras php7.4-fpm postgresql-14
+
+# also install php version 8.1
+sudo apt install -y php8.1 php8.1-fpm php8.1-cli
 
 # now some common PHP extensions ...
 sudo apt install -y php7.4-common php7.4-mysql php7.4-xml php7.4-xmlrpc \
                     php7.4-curl php7.4-gd php7.4-imagick php7.4-cli php7.4-dev \
                     php7.4-imap php7.4-mbstring php7.4-opcache php7.4-soap \
                     php7.4-zip php7.4-intl php7.4-pgsql php7.4-json
+
+# their php 8.1 equivalents ...
+sudo apt install -y php8.1-common php8.1-mysql php8.1-xml php8.1-xmlrpc \
+                    php8.1-curl php8.1-gd php8.1-imagick php8.1-cli php8.1-dev \
+                    php8.1-imap php8.1-mbstring php8.1-opcache php8.1-soap \
+                    php8.1-zip php8.1-intl php8.1-pgsql
+
+# make sure we are using 7.4 cli by default though for now.
+sudo update-alternatives --set php /usr/bin/php7.4

--- a/modules/nginx-php-pgsql.sh
+++ b/modules/nginx-php-pgsql.sh
@@ -5,7 +5,7 @@
 # we already installed all the required ppa's etc in the packages/updates so
 # lets just install
 
-sudo apt install -y nginx nginx-extras php7.4-fpm postgresql-12
+sudo apt install -y nginx nginx-extras php7.4-fpm postgresql-14
 
 # now some common PHP extensions ...
 sudo apt install -y php7.4-common php7.4-mysql php7.4-xml php7.4-xmlrpc \

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -5,7 +5,7 @@
 echo "## Setting up NVM (Node Version Manager) ##"
 echo >> ~/.bashrc
 echo "# Set up NVM" >> ~/.bashrc
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 
 export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -40,9 +40,9 @@ eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
 
 pyenv install 2.7.18
-pyenv install 3.10.4
-# 'python' and 'python3' target 3.10.4 while 'python2' targets 2.7.18
-pyenv global 3.10.4 2.7.18
+pyenv install 3.10.6
+# 'python' and 'python3' target 3.10.6 while 'python2' targets 2.7.18
+pyenv global 3.10.6 2.7.18
 # now update 'pip' in both versions ...
 python2 -m pip install --upgrade pip
 python3 -m pip install --upgrade pip

--- a/modules/updates.sh
+++ b/modules/updates.sh
@@ -13,7 +13,7 @@ sudo apt update
 # some minimal versions of Ubuntu lack these...
 sudo apt-get install -y dialog apt-utils software-properties-common curl wget \
                         ca-certificates gnupg gnupg-agent apt-transport-https \
-                        bash-completion cmake pkg-config iputils-ping
+                        bash-completion cmake pkg-config iputils-ping lsb-release
 
 
 # Add some third-party PPA repos to give us more recent versions of assorted
@@ -33,11 +33,12 @@ curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # add the official Docker repo so we can install recent versions if needed...
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 
 # update then upgrade...
 sudo apt update

--- a/support/.gitconfig
+++ b/support/.gitconfig
@@ -5,6 +5,7 @@
         ci = commit
         cl = clone
         lg = "log --graph --pretty=format:'%C(auto)%h -%d %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+        last = "log -1 HEAD"
 [push]
         default = current
 [credential]
@@ -17,3 +18,5 @@
         pager = less -FRX
 [diff]
         colorMoved = zebra
+[fetch]
+        prune = true


### PR DESCRIPTION
 - Update Python Version to the latest 3.10.6
 - Update to the latest NVM
 - Use the latest Docker install method
 - Install PHP8.1 alongside 7.4; however, 7.4 is the default CLI
 - Upgrade to Postgresql 14