### PR TITLE
Add 'extras' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ functionality :
   (all 3 disabled by default). The default php cli version is explicitly set to
   7.4 for the moment however.
 - Install Docker and Docker-compose (disabled by default)
+- Some useful command-line tools like '[z](https://github.com/rupa/z)' and
+  '[fzf](https://github.com/junegunn/fzf)' installed automatically
 
 ## Security
 

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -74,7 +74,10 @@ fi
 . $THISPATH/modules/node.sh
 . $THISPATH/modules/python.sh
 . $THISPATH/modules/perl.sh
+. $THISPATH/modules/extras.sh
 #. $THISPATH/modules/qemu-kvm.sh
+
+# cleanup after ourselves
 . $THISPATH/modules/cleanup.sh
 
 echo

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# extras.sh
+# extra additions not in the main install script
+
+# install 'z' tool (https://github.com/rupa/z)
+\curl https://raw.githubusercontent.com/rupa/z/master/z.sh ~/.z.sh
+chmod +x ~/.z.sh
+# set up the z tool in the shell
+if ! grep -qc 'z.sh' ~/.bashrc ; then
+  echo >> ~/.bashrc
+  echo "# Set up 'z' (jump around)" >> ~/.bashrc
+  echo '. ~/z.sh' >> ~/.bashrc
+fi
+
+
+# install 'fzf' tool (fuzzy finder)
+git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+~/.fzf/install --all


### PR DESCRIPTION
Add a module for extra items not grouped elsewhere, specifically for installing small CLI programs.

This is run before the cleanup phase.

Currently installs:
- '[z](https://github.com/rupa/z)' (jump around recent directories)
- '[fzf](https://github.com/junegunn/fzf)' (fuzzy finder)