### PR TITLE
Change nginx provider

### DIFF
--- a/modules/nginx-php-pgsql.sh
+++ b/modules/nginx-php-pgsql.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # nginx-php.sh
-# install the Nginx webbrowser, php7.4-fpm and Postgresql database
-# we already installed all the required ppa's etc in the packages/updates so
-# lets just install
+# install the Nginx webbrowser, php8.5-fpm and Postgresql database,
+# plus php8.5 itself. we already installed all the required ppa's etc in the
+# packages/updates so lets just install
 
 echo ""
 echo "---------------------------------------------------------------"
@@ -10,22 +10,22 @@ echo "| Installing Nginx and Postgresql.                            |"
 echo "---------------------------------------------------------------"
 echo ""
 
-sudo DEBIAN_FRONTEND=noninteractive apt install -y nginx nginx-extras php7.4-fpm postgresql-15
+sudo DEBIAN_FRONTEND=noninteractive apt install -y nginx nginx-extras php8.5-fpm
 
-# also install php version 8.1
-sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.1 php8.1-fpm php8.1-cli
+# install php version 8.1
+sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.5 php8.5-cli
 
 # now some common PHP extensions ...
-sudo DEBIAN_FRONTEND=noninteractive apt install -y php7.4-common php7.4-mysql php7.4-xml php7.4-xmlrpc \
-                    php7.4-curl php7.4-gd php7.4-imagick php7.4-cli php7.4-dev \
-                    php7.4-imap php7.4-mbstring php7.4-opcache php7.4-soap \
-                    php7.4-zip php7.4-intl php7.4-pgsql php7.4-json
+# sudo DEBIAN_FRONTEND=noninteractive apt install -y php7.4-common php7.4-mysql php7.4-xml php7.4-xmlrpc \
+#                     php7.4-curl php7.4-gd php7.4-imagick php7.4-cli php7.4-dev \
+#                     php7.4-imap php7.4-mbstring php7.4-opcache php7.4-soap \
+#                     php7.4-zip php7.4-intl php7.4-pgsql php7.4-json
 
-# their php 8.1 equivalents ...
-sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.1-common php8.1-mysql php8.1-xml php8.1-xmlrpc \
-                    php8.1-curl php8.1-gd php8.1-imagick php8.1-cli php8.1-dev \
-                    php8.1-imap php8.1-mbstring php8.1-opcache php8.1-soap \
-                    php8.1-zip php8.1-intl php8.1-pgsql
+# their php 8.5 equivalents ...
+sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.5-common php8.5-mysql php8.5-xml php8.5-xmlrpc \
+                    php8.5-curl php8.5-gd php8.5-imagick php8.5-cli php8.5-dev \
+                    php8.5-imap php8.5-mbstring php8.5-soap \
+                    php8.5-zip php8.5-intl php8.5-pgsql
 
-# make sure we are using 7.4 cli by default though for now.
-sudo update-alternatives --set php /usr/bin/php7.4
+# make sure we are using 8.1 by default
+sudo update-alternatives --set php /usr/bin/php8.5

--- a/modules/updates.sh
+++ b/modules/updates.sh
@@ -29,19 +29,19 @@ if [[ $flavour =~ "ubuntu" ]]; then
   sudo add-apt-repository ppa:git-core/ppa -y
   # add updated php repo ...
   sudo add-apt-repository ppa:ondrej/php -y
-  # add updated Nginx repo, also contains some useful updated libraries ...
-  sudo add-apt-repository ppa:ondrej/nginx -y
 else
   # debian can't use the Ubuntu PPA's
   sudo curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg
   echo \
     "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ \
     $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/php.list > /dev/null
-  sudo curl -sSLo /usr/share/keyrings/deb.sury.org-nginx.gpg https://packages.sury.org/nginx/apt.gpg
-  echo \
-    "deb [signed-by=/usr/share/keyrings/deb.sury.org-nginx.gpg] https://packages.sury.org/nginx/ \
-    $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/nginx.list > /dev/null
 fi
+
+# Add a custom nginx repo with more functionality than the base distro
+curl -sSL https://n.wtf/public.key | sudo gpg --dearmor > /usr/share/keyrings/n.wtf.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/n.wtf.gpg] https://mirror-cdn.xtom.com/sb/nginx/ \
+  $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/n.wtf.list' > /dev/null
 
 # Create the keyring folder if doesn't alredy exist.
 sudo mkdir -p /etc/apt/keyrings
@@ -59,7 +59,7 @@ echo \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # add the GitHub CLI repo so we can install recent versions if needed...
-wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null 
+wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
 sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \


### PR DESCRIPTION
The **sury.org** `nginx` ppa has been discontinued, so replace this with **n.wtf**. This is a similar full-featured distribution of `nginx` with many modules by default.