### PR TITLE
fix: support zsh startup configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,26 @@ functionality :
 - [`Node.js`][node] both the most recent LTS version and latest stable version
   via [`NVM`][nvm]. The LTS version is activated by default.
 - The [`Python`][python] scripting language, latest 3.x version
-  via [`Pyenv`][pyenv]. [Poetry](https://python-poetry.org/) and
-  [PipX](https://pypa.github.io/pipx/) are both pre-installed.
+  via [`Pyenv`][pyenv]. [uv](https://docs.astral.sh/uv/),
+  [Poetry](https://python-poetry.org/) and [PipX](https://pypa.github.io/pipx/)
+  are all pre-installed.
 - The latest version of [`Rust`](https://www.rust-lang.org/) via `rustup`.
 - Install the latest STABLE [`Perl`][perl] scripting language via
   [`Perlbrew`][perlbrew] with cpan and cpanm pre-installed and configured.
   Several PERL modules that make cpan easier are also pre-installed
 - Enable resolution of WINS hostnames
-- [`DISABLED BY DEFAULT`] Install Nginx web server(Latest), PHP(v7.4 & 8.1) and
-  Postgresql database(v14). The default php cli version is explicitly set to 7.4
-  for the moment however.
+- [`DISABLED BY DEFAULT`] Install the latest Nginx web server, PHP 8.5 FPM, CLI,
+  common PHP extensions, and PostgreSQL 18.
 - Install Docker and Docker-compose (unless on WSL2)
-- Some useful command-line tools like '[z](https://github.com/rupa/z)' and
-  '[fzf](https://github.com/junegunn/fzf)' installed automatically
+- Some useful command-line tools are installed automatically, including
+  [zoxide](https://github.com/ajeetdsouza/zoxide),
+  [fzf](https://github.com/junegunn/fzf),
+  [lazygit](https://github.com/jesseduffield/lazygit),
+  [lazydocker](https://github.com/jesseduffield/lazydocker),
+  [bat](https://github.com/sharkdp/bat),
+  [ripgrep](https://github.com/BurntSushi/ripgrep),
+  [fd](https://github.com/sharkdp/fd), and
+  [direnv](https://direnv.net/).
 
 You can enable or disable each module by commenting out the relevant section in
 the `comfy-chair.sh` script.

--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ I have moved away from using WSL, as I have migrated to Linux full-time for my
 development and day-to-day machine, however, I will try to test on WSL and fix
 any errors for each official release.
 
-## Note 2: Currently only for `bash` shell
+## Note 2: Currently only for `bash` and `zsh` shells
 
-The script writes configuration settings to .bashrc, which will mean lack of
-functionality under `Zsh` and others. I now use Zsh myself almost exclusively,
-so this will likely be fixed in future releases.
+The installer uses Bash and expects Bash to be present on the system, which is
+the default on Debian-based distributions. It detects the login shell from
+`$SHELL` and writes configuration to `.bashrc` or `.zshrc`. Other login shells
+are not currently supported.
 
-As a result, under Zsh and others the Pyenv/Rbenv/NVM etc **will not work at
-this time**, though you can certainly move the relevant sections from the
-`.bashrc` to the `.zshrc`
+As a result, under shells other than Bash or Zsh the Pyenv/Rbenv/NVM etc **will
+not work at this time**, though you can certainly move the relevant sections
+from `.bashrc` or `.zshrc` to the correct file for your shell.
 
 ## General Information
 
@@ -121,10 +122,8 @@ with this script.
 
 ## Current Issues/Bugs
 
-- Pyenv, Rbenv, NVM and Perlbrew are only setup for the `Bash` Shell. If you are
-  using another (eg `Zsh`) you will need to copy over the required setup commmands
-  from the `.bashrc` file to the correct file. I'm looking at auto-detecting the
-  running shell and choosing the correct config however.
+- Shell startup configuration is currently generated for Bash and Zsh only.
+  Other shells need manual setup.
 
 ## Usage
 

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -18,6 +18,21 @@ fi
 # get the 'flavour' of this OS, ie debian,ubuntu etc
 flavour=$(tr '[:upper:]' '[:lower:]' <<< `lsb_release -is`)
 
+# detect the user's shell and choose the matching startup file
+shell_type=$(basename "$SHELL")
+case "$shell_type" in
+  bash)
+    shell_rc="$HOME/.bashrc"
+    ;;
+  zsh)
+    shell_rc="$HOME/.zshrc"
+    ;;
+  *)
+    echo "Unsupported shell: $shell_type. Supported shells: bash, zsh."
+    exit 1
+    ;;
+esac
+
 # lets see if we are running under WSL (Windows Subsystem for Linux)
 read osrelease </proc/sys/kernel/osrelease
 if [[ $osrelease =~ "WSL" ]]; then

--- a/modules/cleanup.sh
+++ b/modules/cleanup.sh
@@ -14,8 +14,8 @@ if [ -f "$THISPATH/support/.gitconfig" ] ; then
 fi
 
 # add the .local/bin to the path if it isn't already there...
-if ! grep -qc '/.local/bin' ~/.bashrc ; then
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+if ! grep -qc '/.local/bin' "$shell_rc" ; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
 fi
 # run the above locally to use in this shell
 export PATH="$HOME/.local/bin:$PATH"

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -7,10 +7,10 @@ ARCH=$(dpkg --print-architecture)
 
 # install 'zoxide' tool (this is a faster 'z' tool)
 curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
-if ! grep -qc 'zoxide init' ~/.bashrc ; then
-  echo >> ~/.bashrc
-  echo "# Set up 'zoxide' (jump around)" >> ~/.bashrc
-  echo 'eval "$(zoxide init bash)"' >> ~/.bashrc
+if ! grep -qc 'zoxide init' "$shell_rc" ; then
+  echo >> "$shell_rc"
+  echo "# Set up 'zoxide' (jump around)" >> "$shell_rc"
+  echo "eval \"\$(zoxide init $shell_type)\"" >> "$shell_rc"
 fi
 
 # install 'fzf' tool (fuzzy finder)
@@ -47,8 +47,8 @@ rm ./fd.deb
 
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh | bash
-if ! grep -qc 'direnv hook bash' ~/.bashrc ; then
-  echo >> ~/.bashrc
-  echo "# Set up 'direnv' (environment switcher)" >> ~/.bashrc
-  echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+if ! grep -qc 'direnv hook' "$shell_rc" ; then
+  echo >> "$shell_rc"
+  echo "# Set up 'direnv' (environment switcher)" >> "$shell_rc"
+  echo "eval \"\$(direnv hook $shell_type)\"" >> "$shell_rc"
 fi

--- a/modules/nginx-php-pgsql.sh
+++ b/modules/nginx-php-pgsql.sh
@@ -10,7 +10,7 @@ echo "| Installing Nginx and Postgresql.                            |"
 echo "---------------------------------------------------------------"
 echo ""
 
-sudo DEBIAN_FRONTEND=noninteractive apt install -y nginx nginx-extras php8.5-fpm
+sudo DEBIAN_FRONTEND=noninteractive apt install -y nginx nginx-extras php8.5-fpm postgresql-18
 
 # install php version 8.1
 sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.5 php8.5-cli

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -9,8 +9,8 @@ echo "---------------------------------------------------------------"
 echo ""
 
 echo "## Setting up NVM (Node Version Manager) ##"
-echo >> ~/.bashrc
-echo "# Set up NVM" >> ~/.bashrc
+echo >> "$shell_rc"
+echo "# Set up NVM" >> "$shell_rc"
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
 
 export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -9,11 +9,11 @@ echo "---------------------------------------------------------------"
 echo ""
 
 \curl -L https://install.perlbrew.pl | bash
-if ! grep -qc '~/perl5/perlbrew/etc/bashrc' ~/.bashrc ; then
-  echo "## Adding Perlbrew to .bashrc ##"
-  echo >> ~/.bashrc
-  echo "# Set up Perlbrew" >> ~/.bashrc
-  echo "source ~/perl5/perlbrew/etc/bashrc" >> ~/.bashrc
+if ! grep -qc '~/perl5/perlbrew/etc/bashrc' "$shell_rc" ; then
+  echo "## Adding Perlbrew to $shell_rc ##"
+  echo >> "$shell_rc"
+  echo "# Set up Perlbrew" >> "$shell_rc"
+  echo "source ~/perl5/perlbrew/etc/bashrc" >> "$shell_rc"
 fi
 # source perlbrew setup so we can use in this shell...
 source ~/perl5/perlbrew/etc/bashrc

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -28,14 +28,14 @@ ruff
 ipython
 EOF
 
-if ! grep -qc 'pyenv init' ~/.bashrc ; then
-  echo "## Adding pyenv to .bashrc ##"
-  echo >> ~/.bashrc
-  echo "# Set up Pyenv" >> ~/.bashrc
-  echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-  echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-  echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-  echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
+if ! grep -qc 'pyenv init' "$shell_rc" ; then
+  echo "## Adding pyenv to $shell_rc ##"
+  echo >> "$shell_rc"
+  echo "# Set up Pyenv" >> "$shell_rc"
+  echo 'export PYENV_ROOT="$HOME/.pyenv"' >> "$shell_rc"
+  echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> "$shell_rc"
+  echo "eval \"\$(pyenv init - $shell_type)\"" >> "$shell_rc"
+  echo 'eval "$(pyenv virtualenv-init -)"' >> "$shell_rc"
 fi
 # run the above locally to use in this shell
 export PYENV_ROOT="$HOME/.pyenv"
@@ -49,8 +49,8 @@ pyenv global 3.14
 python3 -m pip install --upgrade pip
 
 # add the .local/bin to the path if it isn't already there...
-if ! grep -qc '/.local/bin' ~/.bashrc ; then
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+if ! grep -qc '/.local/bin' "$shell_rc" ; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
 fi
 # run the above locally to use in this shell
 export PATH="$HOME/.local/bin:$PATH"
@@ -68,8 +68,8 @@ python3 -m pip install --user pipx
 pipx ensurepath
 
 # add autocompletion for pipx
-if ! grep -qc 'pipx' ~/.bashrc ; then
-  echo 'eval "$(register-python-argcomplete pipx)"' >> ~/.bashrc
+if ! grep -qc 'pipx' "$shell_rc" ; then
+  echo 'eval "$(register-python-argcomplete pipx)"' >> "$shell_rc"
 fi
 
 # run the above locally to use in this shell

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -13,12 +13,12 @@ curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer
 # install dynamic bash extension
 cd ~/.rbenv && src/configure && make -C src
 # add the rbenv setup to our profile, only if it is not already there
-if ! grep -qc 'rbenv init' ~/.bashrc ; then
-  echo "## Adding rbenv to .bashrc ##"
-  echo >> ~/.bashrc
-  echo "# Set up Rbenv" >> ~/.bashrc
-  echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-  echo 'eval "$(rbenv init - bash)"' >> ~/.bashrc
+if ! grep -qc 'rbenv init' "$shell_rc" ; then
+  echo "## Adding rbenv to $shell_rc ##"
+  echo >> "$shell_rc"
+  echo "# Set up Rbenv" >> "$shell_rc"
+  echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> "$shell_rc"
+  echo "eval \"\$(rbenv init - $shell_type)\"" >> "$shell_rc"
 fi
 # run the above command locally so we can get rbenv to work on this provisioning shell
 eval "$(rbenv init - bash)"


### PR DESCRIPTION
## Summary

This updates shell startup configuration so the installer detects the user login shell and writes persistent tool setup to `.bashrc` or `.zshrc` for Bash and Zsh users.

It also refreshes the related README feature list and web stack details: Python tooling now mentions uv, the extras list reflects the currently installed tools, and the disabled Nginx/PHP/PostgreSQL module installs PostgreSQL 18 alongside PHP 8.5.

Fixes #16.