### PR TITLE
feat: add Docker test harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:24.04
+
+ARG USERNAME=comfy
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/home/${USERNAME}
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    apt-utils \
+    bash \
+    ca-certificates \
+    curl \
+    dialog \
+    git \
+    gnupg \
+    less \
+    locales \
+    lsb-release \
+    nano \
+    procps \
+    sudo \
+    wget \
+    zsh \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN existing_group="$(getent group "${USER_GID}" | cut -d: -f1 || true)" \
+  && if [ -z "$existing_group" ]; then groupadd --gid "${USER_GID}" "${USERNAME}"; fi \
+  && existing_user="$(getent passwd "${USER_UID}" | cut -d: -f1 || true)" \
+  && if [ -n "$existing_user" ] && [ "$existing_user" != "$USERNAME" ]; then usermod --login "${USERNAME}" --home "/home/${USERNAME}" --move-home "$existing_user"; fi \
+  && if getent passwd "${USERNAME}" >/dev/null; then usermod --gid "${USER_GID}" --shell /bin/bash "${USERNAME}"; else useradd --uid "${USER_UID}" --gid "${USER_GID}" --create-home --shell /bin/bash "${USERNAME}"; fi \
+  && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${USERNAME}" \
+  && chmod 0440 "/etc/sudoers.d/${USERNAME}" \
+  && mkdir -p "/home/${USERNAME}/comfy-chair" \
+  && printf '%s\n' 'echo "Exiting container; Docker is removing the disposable test environment..."' > "/home/${USERNAME}/.bash_logout" \
+  && printf '%s\n' 'echo "Exiting container; Docker is removing the disposable test environment..."' > "/home/${USERNAME}/.zlogout" \
+  && chown -R "${USER_UID}:${USER_GID}" "/home/${USERNAME}"
+
+COPY support/docker-entrypoint.sh /usr/local/bin/comfy-docker-entrypoint
+RUN chmod 0755 /usr/local/bin/comfy-docker-entrypoint
+
+USER "${USERNAME}"
+WORKDIR "/home/${USERNAME}/comfy-chair"
+
+ENTRYPOINT ["/usr/local/bin/comfy-docker-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ cd linux-comfy-chair
 ./comfy-chair.sh
 ```
 
+### Local Docker test shell
+
+For local testing without modifying your host system, you can start an
+ephemeral Ubuntu 24.04 container:
+
+```bash
+./docker-shell.sh
+```
+
+The helper builds a local test image, starts a fresh container, mounts this
+repository at `~/comfy-chair`, and asks whether to log in with Bash or Zsh. The
+container user is created with your host UID and GID, so the bind-mounted
+working tree remains writable. The container is removed when you exit, so
+installed packages and system changes do not persist.
+
+When `./comfy-chair.sh` runs inside ANY container, it skips the Docker install
+module to avoid trying to install Docker inside Docker.
+
+Obviously, you need to have `Docker` installed already on your local machine.
+
 ### Default branch has been renamed
 
 In line with many Open-Source projects, I have renamed the Default branch from

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -41,9 +41,18 @@ else
   os="linux"
 fi
 
+if [ -f /.dockerenv ] || grep -qaE '(docker|containerd|kubepods)' /proc/1/cgroup 2>/dev/null; then
+  running_in_container="yes"
+else
+  running_in_container="no"
+fi
+
 echo "Linux Comfy Chair v$VERSION (c) Grant Ramsay (seapagan@gmail.com)"
 if [ $os = "wsl" ]; then
   echo " - Running under the 'Windows Subsystem for Linux (WSL)"
+fi
+if [ "$running_in_container" = "yes" ]; then
+  echo " - Running inside a container"
 fi
 
 # save the path to this script for later use
@@ -88,7 +97,11 @@ fi
 # ---------------------------------------------------------------------------- #
 # . $THISPATH/modules/nginx-php-pgsql.sh
 . $THISPATH/modules/rust.sh
-. $THISPATH/modules/docker.sh
+if [ "$running_in_container" = "yes" ]; then
+  echo "Skipping Docker install inside a container."
+else
+  . $THISPATH/modules/docker.sh
+fi
 . $THISPATH/modules/ruby.sh
 . $THISPATH/modules/node.sh
 . $THISPATH/modules/python.sh
@@ -102,4 +115,5 @@ fi
 . $THISPATH/modules/cleanup.sh
 
 echo
-echo "You now need to reboot this system for all the new changes to take affect."
+echo "You now need to reboot this system for all the new changes to take " \
+  "effect, or at least re-exec your shell (eg 'exec \$SHELL') to use the tools."

--- a/docker-shell.sh
+++ b/docker-shell.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image_name="${COMFY_DOCKER_IMAGE:-linux-comfy-chair-dev}"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+docker build \
+  --build-arg USER_UID="$(id -u)" \
+  --build-arg USER_GID="$(id -g)" \
+  --tag "$image_name" \
+  "$script_dir"
+
+echo "Starting disposable Ubuntu test container. Exit the shell to remove it."
+set +e
+docker run \
+  --rm \
+  --interactive \
+  --tty \
+  --mount "type=bind,src=${script_dir},target=/home/comfy/comfy-chair" \
+  "$image_name"
+status=$?
+set -e
+echo "Disposable container removed."
+exit "$status"

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -45,6 +45,14 @@ curl -Lo fd.deb "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/
 sudo dpkg -i fd.deb
 rm ./fd.deb
 
+# ensure we can find nvim if installed by bob:
+if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
+  echo >> "$shell_rc"
+  echo "# so we can find nvim" >> "$shell_rc"
+  echo 'export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"' >> "$shell_rc"
+fi
+
+
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh | bash
 if ! grep -qc 'direnv hook' "$shell_rc" ; then

--- a/modules/updates.sh
+++ b/modules/updates.sh
@@ -41,9 +41,9 @@ fi
 curl -sSL https://n.wtf/public.key | sudo gpg --dearmor > /usr/share/keyrings/n.wtf.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/n.wtf.gpg] https://mirror-cdn.xtom.com/sb/nginx/ \
-  $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/n.wtf.list' > /dev/null
+  $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/n.wtf.list > /dev/null
 
-# Create the keyring folder if doesn't alredy exist.
+# Create the keyring folder if doesn't already exist.
 sudo mkdir -p /etc/apt/keyrings
 
 # add Postgresql repo so we can get latest versions if needed...

--- a/support/docker-entrypoint.sh
+++ b/support/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$HOME/comfy-chair"
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
+if [ ! -t 0 ]; then
+  exec /bin/bash -l
+fi
+
+while true; do
+  echo
+  echo "Choose a shell:"
+  echo "  1) Bash"
+  echo "  2) Zsh"
+  read -r -p "> " choice
+
+  case "$choice" in
+    1|bash|Bash|BASH)
+      export SHELL=/bin/bash
+      exec /bin/bash -l
+      ;;
+    2|zsh|Zsh|ZSH)
+      export SHELL=/bin/zsh
+      exec /bin/zsh -l
+      ;;
+    *)
+      echo "Please choose 1 or 2."
+      ;;
+  esac
+done


### PR DESCRIPTION
Adds a disposable Ubuntu 24.04 Docker test harness for running the bootstrapper locally without modifying the host system. The helper builds a local image, mounts the working tree into a normal non-root container user, and prompts for Bash or Zsh so shell-specific setup can be exercised.

The installer now detects container environments and skips the Docker install module there, avoiding nested Docker setup during local harness runs. This also includes the README usage notes, the nginx repo quoting fix in `updates.sh`, the `bob` nvim PATH hook in `extras.sh`, and the updated final shell re-exec message.

No related issue.
