### PR TITLE
fix: clean up shellcheck warnings

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/README.md
+++ b/README.md
@@ -184,6 +184,23 @@ Optionally, also remove any tracking references to the old branch name :
 git remote prune origin
 ```
 
+## Development checks
+
+Run the shell syntax and ShellCheck validation with:
+
+```bash
+./scripts/check-shell.sh
+```
+
+This requires `shellcheck`; on Ubuntu, install it with:
+
+```bash
+sudo apt install shellcheck
+```
+
+The check validates the main bootstrapper and follows its sourced modules in
+context.
+
 ## To-Do
 
 - More robust fall-over on already configured systems. If Rbenv etc are already

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -9,14 +9,14 @@ export DEBIAN_FRONTEND=noninteractive
 
 # make sure we are running under a Debian-based OS, as this script needs the
 # 'apt' command and their specific packages.
-debian=`dpkg --version | grep "Debian"`
+debian=$(dpkg --version | grep "Debian")
 if [ -z "$debian" ]; then
   echo "This script is only for Debian-based systems."
   exit 1
 fi
 
 # get the 'flavour' of this OS, ie debian,ubuntu etc
-flavour=$(tr '[:upper:]' '[:lower:]' <<< `lsb_release -is`)
+flavour=$(tr '[:upper:]' '[:lower:]' <<< "$(lsb_release -is)")
 
 # detect the user's shell and choose the matching startup file
 shell_type=$(basename "$SHELL")
@@ -34,7 +34,7 @@ case "$shell_type" in
 esac
 
 # lets see if we are running under WSL (Windows Subsystem for Linux)
-read osrelease </proc/sys/kernel/osrelease
+read -r osrelease </proc/sys/kernel/osrelease
 if [[ $osrelease =~ "WSL" ]]; then
   os="wsl"
 else
@@ -48,7 +48,7 @@ else
 fi
 
 echo "Linux Comfy Chair v$VERSION (c) Grant Ramsay (seapagan@gmail.com)"
-if [ $os = "wsl" ]; then
+if [ "$os" = "wsl" ]; then
   echo " - Running under the 'Windows Subsystem for Linux (WSL)"
 fi
 if [ "$running_in_container" = "yes" ]; then
@@ -56,14 +56,14 @@ if [ "$running_in_container" = "yes" ]; then
 fi
 
 # save the path to this script for later use
-THISPATH="$(dirname $(readlink -f "$0"))"
+THISPATH="$(dirname "$(readlink -f "$0")")"
 echo
 echo "We are running from : $THISPATH"
 echo
 
 # make sure we have Git and sudo installed already. Some very minimal images
 # will not have these (eg the standard Ubuntu Docker image)
-if [ ! $(which git) ] || [ ! $(which sudo) ]; then
+if ! command -v git >/dev/null || ! command -v sudo >/dev/null; then
   echo "Git or/and Sudo are not installed, please install these and restart."
   exit 1
 fi
@@ -80,39 +80,39 @@ if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
 fi
 
 # source in the configuration file..
-. $THISPATH/comfy.config
+. "$THISPATH/comfy.config"
 
 # run the individual modules. This will be changed to read from an array of
 # modules..
-. $THISPATH/modules/updates.sh $flavour
-. $THISPATH/modules/packages.sh
+. "$THISPATH/modules/updates.sh" "$flavour"
+. "$THISPATH/modules/packages.sh"
 
 # WSL Specific work
-if [ $os = "wsl" ]; then
-  . $THISPATH/modules/wsl.sh
+if [ "$os" = "wsl" ]; then
+  . "$THISPATH/modules/wsl.sh"
 fi
 
 # ---------------------------------------------------------------------------- #
 #             comment out the modules below you do not want to run             #
 # ---------------------------------------------------------------------------- #
 # . $THISPATH/modules/nginx-php-pgsql.sh
-. $THISPATH/modules/rust.sh
+. "$THISPATH/modules/rust.sh"
 if [ "$running_in_container" = "yes" ]; then
   echo "Skipping Docker install inside a container."
 else
-  . $THISPATH/modules/docker.sh
+  . "$THISPATH/modules/docker.sh"
 fi
-. $THISPATH/modules/ruby.sh
-. $THISPATH/modules/node.sh
-. $THISPATH/modules/python.sh
-. $THISPATH/modules/perl.sh
-. $THISPATH/modules/extras.sh
+. "$THISPATH/modules/ruby.sh"
+. "$THISPATH/modules/node.sh"
+. "$THISPATH/modules/python.sh"
+. "$THISPATH/modules/perl.sh"
+. "$THISPATH/modules/extras.sh"
 # ---------------------------------------------------------------------------- #
 #                                end of modules                                #
 # ---------------------------------------------------------------------------- #
 
 # cleanup after ourselves
-. $THISPATH/modules/cleanup.sh
+. "$THISPATH/modules/cleanup.sh"
 
 echo
 echo "You now need to reboot this system for all the new changes to take " \

--- a/modules/cleanup.sh
+++ b/modules/cleanup.sh
@@ -10,7 +10,7 @@ echo ""
 
 # copy a basic .gitconfig if we have it...
 if [ -f "$THISPATH/support/.gitconfig" ] ; then
-  cat $THISPATH/support/.gitconfig >> ~/.gitconfig
+  cat "$THISPATH/support/.gitconfig" >> ~/.gitconfig
 fi
 
 # add the .local/bin to the path if it isn't already there...

--- a/modules/docker.sh
+++ b/modules/docker.sh
@@ -9,12 +9,12 @@ echo "---------------------------------------------------------------"
 echo ""
 
 # DONT DO ANY OF THIS IN WSL (Windows Subsystem for Linux)!
-if [ ! $os = "wsl" ]; then
+if [ "$os" != "wsl" ]; then
   # docker. We no longer use the old V1 of docker compose, we install v2.
   sudo DEBIAN_FRONTEND=noninteractive apt install -y docker-ce docker-ce-cli \
         containerd.io docker-buildx-plugin docker-compose-plugin
   # remove the need for sudo...
-  sudo usermod -aG docker $USER
+  sudo usermod -aG docker "$USER"
 else
   echo
   echo " -<[ Skipping Docker in WSL ]>- "

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -13,9 +13,10 @@ echo >> "$shell_rc"
 echo "# Set up NVM" >> "$shell_rc"
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
 
-export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+export NVM_DIR
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-[[ -r $NVM_DIR/bash_completion ]] && \. $NVM_DIR/bash_completion # This loads nvm bash_completion
+[[ -r $NVM_DIR/bash_completion ]] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
 
 # set up some default packages to always install - these 2 allow the use of a
 # '.node-version' file which will choose the version of node to make default on

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -9,14 +9,14 @@ echo "---------------------------------------------------------------"
 echo ""
 
 \curl -L https://install.perlbrew.pl | bash
-if ! grep -qc '~/perl5/perlbrew/etc/bashrc' "$shell_rc" ; then
+if ! grep -qc 'perl5/perlbrew/etc/bashrc' "$shell_rc" ; then
   echo "## Adding Perlbrew to $shell_rc ##"
   echo >> "$shell_rc"
   echo "# Set up Perlbrew" >> "$shell_rc"
-  echo "source ~/perl5/perlbrew/etc/bashrc" >> "$shell_rc"
+  echo 'source "$HOME/perl5/perlbrew/etc/bashrc"' >> "$shell_rc"
 fi
 # source perlbrew setup so we can use in this shell...
-source ~/perl5/perlbrew/etc/bashrc
+source "$HOME/perl5/perlbrew/etc/bashrc"
 
 # install perl and select it...
 perlbrew install perl-5.42.2

--- a/modules/updates.sh
+++ b/modules/updates.sh
@@ -38,7 +38,7 @@ else
 fi
 
 # Add a custom nginx repo with more functionality than the base distro
-curl -sSL https://n.wtf/public.key | sudo gpg --dearmor > /usr/share/keyrings/n.wtf.gpg
+curl -sSL https://n.wtf/public.key | sudo gpg --dearmor -o /usr/share/keyrings/n.wtf.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/n.wtf.gpg] https://mirror-cdn.xtom.com/sb/nginx/ \
   $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/n.wtf.list > /dev/null
@@ -53,7 +53,7 @@ sudo echo \
   $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
 
 # add the official Docker repo so we can install recent versions if needed...
-curl -fsSL https://download.docker.com/linux/$flavour/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL https://download.docker.com/linux/"$flavour"/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$flavour \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null

--- a/modules/wsl.sh
+++ b/modules/wsl.sh
@@ -4,7 +4,7 @@
 # system ...we install a meta-package for Ubuntu after first checking we are
 # definately using Ubuntu.
 
-distro=`cat /etc/*-release | grep DISTRIB_ID | awk -F= '{print $2}'`
+distro=$(grep -h 'DISTRIB_ID' /etc/*-release | awk -F= '{print $2}')
 
 if [ "$distro" == "Ubuntu" ]; then
   echo ""

--- a/scripts/check-shell.sh
+++ b/scripts/check-shell.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bash -n comfy-chair.sh modules/*.sh docker-shell.sh support/docker-entrypoint.sh
+
+if command -v shellcheck >/dev/null; then
+  shellcheck -x comfy-chair.sh docker-shell.sh support/docker-entrypoint.sh
+else
+  echo "shellcheck is not installed; skipping ShellCheck."
+  echo "On Ubuntu, install it with: sudo apt install shellcheck"
+fi


### PR DESCRIPTION
Cleans up behavior-relevant ShellCheck findings in the bootstrap scripts by quoting sourced paths and command arguments, replacing legacy command substitutions, and fixing privileged keyring output for the nginx repository.

Adds a small `scripts/check-shell.sh` helper and `.shellcheckrc` so the intended shell validation path is easy to run. The helper always runs Bash syntax checks, then runs ShellCheck when available with sourced modules followed through `comfy-chair.sh`.