### PR TITLE
Add new tools and update versions of existing as required

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,5 +7,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+language: "en-US"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.sh]
+indent_style = space
+indent_size = 2
+switch_case_indent = true
+space_redirects = true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,13 +6,14 @@ about: Suggest an idea for this project
 
 # Is your feature request related to a problem? Please describe
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've considered** A clear and concise description of
+any alternative solutions or features you've considered.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,8 @@ Fix bugs/typos causing the 'z.sh' install to fail.
 
 **_The Old Garden seat (in the sun)_**
 
-* Update Python and Ruby to the latest versions.
-* Ensure the `docker-buildx` plugin is installed.
+- Update Python and Ruby to the latest versions.
+- Ensure the `docker-buildx` plugin is installed.
 
 [`Full Changelog`](https://github.com/seapagan/linux-comfy-chair/compare/1.4.1...1.4.2) | [`Diff`](https://github.com/seapagan/linux-comfy-chair/compare/1.4.1...1.4.2.diff) | [`Patch`](https://github.com/seapagan/linux-comfy-chair/compare/1.4.1...1.4.2.patch)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ functionality :
   [cargo-make](https://github.com/sagiegurari/cargo-make).
 - Install the latest STABLE [`Perl`][perl] scripting language via
   [`Perlbrew`][perlbrew] with cpan and cpanm pre-installed and configured.
-  Several PERL modules that make cpan easier are also pre-installed
+  Several Perl modules that make CPAN easier to use are also pre-installed.
 - Enable resolution of WINS hostnames
 - [`DISABLED BY DEFAULT`] Install the latest Nginx web server, PHP 8.5 FPM, CLI,
   common PHP extensions, and PostgreSQL 18.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ from `.bashrc` or `.zshrc` to the correct file for your shell.
 
 ## General Information
 
+> [!IMPORTANT]
+> This bootstrapper deliberately installs the latest stable packages and tools
+> available at provisioning time. APT packages and most third-party tools are
+> intentionally not pinned, so separate runs may install different versions.
+> It is not intended to produce bit-for-bit reproducible systems.
+
 The script works on a bare newly installed system and provides the following
 functionality :
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ functionality :
   via [`NVM`][nvm]. The LTS version is activated by default.
 - The [`Python`][python] scripting language, latest 3.x version
   via [`Pyenv`][pyenv]. [uv](https://docs.astral.sh/uv/),
-  [Poetry](https://python-poetry.org/) and [PipX](https://pypa.github.io/pipx/)
-  are all pre-installed.
-- The latest version of [`Rust`](https://www.rust-lang.org/) via `rustup`.
+  [Poetry](https://python-poetry.org/), [PipX](https://pypa.github.io/pipx/),
+  and [Ruff](https://github.com/astral-sh/ruff) are all pre-installed.
+- The latest version of [`Rust`](https://www.rust-lang.org/) via `rustup`, with
+  [cargo-binstall](https://github.com/cargo-bins/cargo-binstall),
+  [cargo-edit](https://github.com/killercup/cargo-edit), and
+  [cargo-make](https://github.com/sagiegurari/cargo-make).
 - Install the latest STABLE [`Perl`][perl] scripting language via
   [`Perlbrew`][perlbrew] with cpan and cpanm pre-installed and configured.
   Several PERL modules that make cpan easier are also pre-installed
@@ -105,15 +108,32 @@ functionality :
 - [`DISABLED BY DEFAULT`] Install the latest Nginx web server, PHP 8.5 FPM, CLI,
   common PHP extensions, and PostgreSQL 18.
 - Install Docker and Docker-compose (unless on WSL2)
-- Some useful command-line tools are installed automatically, including
-  [zoxide](https://github.com/ajeetdsouza/zoxide),
-  [fzf](https://github.com/junegunn/fzf),
-  [lazygit](https://github.com/jesseduffield/lazygit),
-  [lazydocker](https://github.com/jesseduffield/lazydocker),
-  [bat](https://github.com/sharkdp/bat),
-  [ripgrep](https://github.com/BurntSushi/ripgrep),
-  [fd](https://github.com/sharkdp/fd), and
-  [direnv](https://direnv.net/).
+- Some useful command-line tools are installed automatically:
+  - Navigation and search: [zoxide](https://github.com/ajeetdsouza/zoxide),
+    [fzf](https://github.com/junegunn/fzf),
+    [Yazi](https://github.com/sxyazi/yazi),
+    [Television](https://github.com/alexpasmantier/television), and
+    [direnv](https://direnv.net/).
+  - Git and containers: [GitHub CLI](https://github.com/cli/cli),
+    [lazygit](https://github.com/jesseduffield/lazygit),
+    [delta](https://github.com/dandavison/delta), and
+    [lazydocker](https://github.com/jesseduffield/lazydocker).
+  - Files and storage: [bat](https://github.com/sharkdp/bat),
+    [ripgrep](https://github.com/BurntSushi/ripgrep),
+    [fd](https://github.com/sharkdp/fd),
+    [lsplus](https://github.com/seapagan/lsplus),
+    [dust](https://github.com/bootandy/dust), and
+    [duf](https://github.com/muesli/duf).
+  - Shell and development: [Atuin](https://github.com/atuinsh/atuin),
+    [Bob](https://github.com/MordechaiHadad/bob),
+    [ShellCheck](https://github.com/koalaman/shellcheck),
+    [shfmt](https://github.com/mvdan/sh),
+    [hyperfine](https://github.com/sharkdp/hyperfine), and
+    [Watchexec](https://github.com/watchexec/watchexec).
+  - Data and HTTP: [jq](https://github.com/jqlang/jq),
+    [yq](https://github.com/mikefarah/yq),
+    [xh](https://github.com/ducaale/xh), and
+    [Tokei](https://github.com/XAMPPRocky/tokei).
 
 You can enable or disable each module by commenting out the relevant section in
 the `comfy-chair.sh` script.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,13 @@
 # TODO
 
+## Docker Test Environment
+
+- Add a `--keep` option to `docker-shell.sh` that omits `docker run --rm` and
+  gives the retained container a unique, reported name. Allow it to be combined
+  with `--log` in either order, retain the container after both successful and
+  failed runs, and print commands for restarting, inspecting, copying files
+  from, and removing it.
+
 ## Low-Space and Low-Memory Systems
 
 Notes from testing on a Raspberry Pi 3 with 1 GB RAM and Raspberry Pi OS Trixie

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -34,6 +34,7 @@ case "$shell_type" in
 esac
 
 # add .local/bin to the path for user-installed tools
+mkdir -p "$HOME/.local/bin"
 if ! grep -qc '/.local/bin' "$shell_rc"; then
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
 fi

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -61,6 +61,21 @@ record_failed_install() {
   failed_installs+=("$component")
 }
 
+run_downloaded_installer() {
+  local component=$1
+  local url=$2
+  local filename=$3
+  local interpreter=$4
+  local installer="$install_tmp_dir/$filename"
+  shift 4
+
+  if ! curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$installer" ||
+    ! (cd "$install_tmp_dir" && "$interpreter" "$installer" "$@"); then
+    record_failed_install "$component"
+    return 1
+  fi
+}
+
 install_with_cargo_binstall() {
   local package=$1
   if ! command -v cargo-binstall > /dev/null; then

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -35,7 +35,7 @@ esac
 
 # add .local/bin to the path for user-installed tools
 mkdir -p "$HOME/.local/bin"
-if ! grep -qc '/.local/bin' "$shell_rc"; then
+if ! grep -q '/.local/bin' "$shell_rc"; then
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
 fi
 export PATH="$HOME/.local/bin:$PATH"

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -108,6 +108,16 @@ if ! command -v git > /dev/null || ! command -v sudo > /dev/null; then
   exit 1
 fi
 
+# keep installation downloads and extracted files out of the working directory
+if ! install_tmp_dir=$(mktemp -d -t "comfy-chair.XXXXXX"); then
+  echo "Could not create a temporary installation directory."
+  exit 1
+fi
+cleanup_install_tmp() {
+  rm -rf -- "$install_tmp_dir"
+}
+trap cleanup_install_tmp EXIT
+
 # if this is a minimized system (eg ex Docker container) then the 'man' command
 # will be diverted to a stub. Lets set this back to the real Binary
 # Note : Without this the Perl installation will FAIL tests.

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -34,20 +34,20 @@ case "$shell_type" in
 esac
 
 # add .local/bin to the path for user-installed tools
-if ! grep -qc '/.local/bin' "$shell_rc" ; then
+if ! grep -qc '/.local/bin' "$shell_rc"; then
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
 fi
 export PATH="$HOME/.local/bin:$PATH"
 
 # lets see if we are running under WSL (Windows Subsystem for Linux)
-read -r osrelease </proc/sys/kernel/osrelease
+read -r osrelease < /proc/sys/kernel/osrelease
 if [[ $osrelease =~ "WSL" ]]; then
   os="wsl"
 else
   os="linux"
 fi
 
-if [ -f /.dockerenv ] || grep -qaE '(docker|containerd|kubepods)' /proc/1/cgroup 2>/dev/null; then
+if [ -f /.dockerenv ] || grep -qaE '(docker|containerd|kubepods)' /proc/1/cgroup 2> /dev/null; then
   running_in_container="yes"
 else
   running_in_container="no"
@@ -69,7 +69,7 @@ echo
 
 # make sure we have Git and sudo installed already. Some very minimal images
 # will not have these (eg the standard Ubuntu Docker image)
-if ! command -v git >/dev/null || ! command -v sudo >/dev/null; then
+if ! command -v git > /dev/null || ! command -v sudo > /dev/null; then
   echo "Git or/and Sudo are not installed, please install these and restart."
   exit 1
 fi
@@ -77,12 +77,12 @@ fi
 # if this is a minimized system (eg ex Docker container) then the 'man' command
 # will be diverted to a stub. Lets set this back to the real Binary
 # Note : Without this the Perl installation will FAIL tests.
-if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
-    # Remove diverted man binary
-    sudo rm -f /usr/bin/man
-    sudo dpkg-divert --quiet --remove --rename /usr/bin/man
-    # remove the reminder from the MOTD
-    sudo rm -f /etc/update-motd.d/60-unminimize
+if [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
+  # Remove diverted man binary
+  sudo rm -f /usr/bin/man
+  sudo dpkg-divert --quiet --remove --rename /usr/bin/man
+  # remove the reminder from the MOTD
+  sudo rm -f /etc/update-motd.d/60-unminimize
 fi
 
 # source in the configuration file..

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -47,6 +47,7 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # collect optional installation failures across sourced modules
 failed_installs=()
+skipped_cargo_installs=()
 
 record_failed_install() {
   local component=$1
@@ -64,6 +65,7 @@ install_with_cargo_binstall() {
   local package=$1
   if ! command -v cargo-binstall > /dev/null; then
     record_failed_install cargo-binstall
+    skipped_cargo_installs+=("$package")
     return
   fi
   if ! cargo binstall "$package" --no-confirm; then
@@ -160,4 +162,11 @@ if ((${#failed_installs[@]} > 0)); then
   echo
   echo "The following optional components could not be installed or updated:"
   printf ' - %s\n' "${failed_installs[@]}"
+fi
+
+if ((${#skipped_cargo_installs[@]} > 0)); then
+  echo
+  printf 'Rust tools skipped because cargo-binstall was unavailable:'
+  printf ' %s' "${skipped_cargo_installs[@]}"
+  echo
 fi

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -50,14 +50,23 @@ failed_installs=()
 
 record_failed_install() {
   local component=$1
+  local failed_component
+  for failed_component in "${failed_installs[@]}"; do
+    if [ "$failed_component" = "$component" ]; then
+      return
+    fi
+  done
   echo "Warning: failed to install or update '$component'."
   failed_installs+=("$component")
 }
 
 install_with_cargo_binstall() {
   local package=$1
-  if ! command -v cargo-binstall > /dev/null ||
-    ! cargo binstall "$package" --no-confirm; then
+  if ! command -v cargo-binstall > /dev/null; then
+    record_failed_install cargo-binstall
+    return
+  fi
+  if ! cargo binstall "$package" --no-confirm; then
     record_failed_install "$package"
   fi
 }

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -33,6 +33,12 @@ case "$shell_type" in
     ;;
 esac
 
+# add .local/bin to the path for user-installed tools
+if ! grep -qc '/.local/bin' "$shell_rc" ; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
 # lets see if we are running under WSL (Windows Subsystem for Linux)
 read -r osrelease </proc/sys/kernel/osrelease
 if [[ $osrelease =~ "WSL" ]]; then

--- a/comfy-chair.sh
+++ b/comfy-chair.sh
@@ -33,12 +33,34 @@ case "$shell_type" in
     ;;
 esac
 
+# ensure the selected shell startup file exists before inspecting it
+if [ ! -e "$shell_rc" ]; then
+  touch "$shell_rc"
+fi
+
 # add .local/bin to the path for user-installed tools
 mkdir -p "$HOME/.local/bin"
 if ! grep -q '/.local/bin' "$shell_rc"; then
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
 fi
 export PATH="$HOME/.local/bin:$PATH"
+
+# collect optional installation failures across sourced modules
+failed_installs=()
+
+record_failed_install() {
+  local component=$1
+  echo "Warning: failed to install or update '$component'."
+  failed_installs+=("$component")
+}
+
+install_with_cargo_binstall() {
+  local package=$1
+  if ! command -v cargo-binstall > /dev/null ||
+    ! cargo binstall "$package" --no-confirm; then
+    record_failed_install "$package"
+  fi
+}
 
 # lets see if we are running under WSL (Windows Subsystem for Linux)
 read -r osrelease < /proc/sys/kernel/osrelease
@@ -124,3 +146,9 @@ fi
 echo
 echo "You now need to reboot this system for all the new changes to take " \
   "effect, or at least re-exec your shell (eg 'exec \$SHELL') to use the tools."
+
+if ((${#failed_installs[@]} > 0)); then
+  echo
+  echo "The following optional components could not be installed or updated:"
+  printf ' - %s\n' "${failed_installs[@]}"
+fi

--- a/modules/cleanup.sh
+++ b/modules/cleanup.sh
@@ -9,6 +9,6 @@ echo "---------------------------------------------------------------"
 echo
 
 # copy a basic .gitconfig if we have it...
-if [ -f "$THISPATH/support/.gitconfig" ] ; then
+if [ -f "$THISPATH/support/.gitconfig" ]; then
   cat "$THISPATH/support/.gitconfig" >> ~/.gitconfig
 fi

--- a/modules/cleanup.sh
+++ b/modules/cleanup.sh
@@ -2,11 +2,11 @@
 # cleanup.sh
 # any last tidy and config changes to be done
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Performing Clean-up tasks.                                  |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 # copy a basic .gitconfig if we have it...
 if [ -f "$THISPATH/support/.gitconfig" ] ; then

--- a/modules/cleanup.sh
+++ b/modules/cleanup.sh
@@ -12,10 +12,3 @@ echo ""
 if [ -f "$THISPATH/support/.gitconfig" ] ; then
   cat "$THISPATH/support/.gitconfig" >> ~/.gitconfig
 fi
-
-# add the .local/bin to the path if it isn't already there...
-if ! grep -qc '/.local/bin' "$shell_rc" ; then
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
-fi
-# run the above locally to use in this shell
-export PATH="$HOME/.local/bin:$PATH"

--- a/modules/docker.sh
+++ b/modules/docker.sh
@@ -2,11 +2,11 @@
 # docker.sh
 # install docker and docker-compose
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Docker and Compose.                              |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 # DONT DO ANY OF THIS IN WSL (Windows Subsystem for Linux)!
 if [ "$os" != "wsl" ]; then

--- a/modules/docker.sh
+++ b/modules/docker.sh
@@ -12,7 +12,7 @@ echo
 if [ "$os" != "wsl" ]; then
   # docker. We no longer use the old V1 of docker compose, we install v2.
   sudo DEBIAN_FRONTEND=noninteractive apt install -y docker-ce docker-ce-cli \
-        containerd.io docker-buildx-plugin docker-compose-plugin
+    containerd.io docker-buildx-plugin docker-compose-plugin
   # remove the need for sudo...
   sudo usermod -aG docker "$USER"
 else

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -128,6 +128,63 @@ curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | sh
 # install 'watchexec' command runner
 cargo binstall watchexec-cli --no-confirm
 
+# map Debian architecture names to upstream release asset names
+case "$ARCH" in
+  amd64)
+    SHELLCHECK_ARCH="x86_64"
+    SHFMT_ARCH="amd64"
+    YQ_ARCH="amd64"
+    ;;
+  arm64)
+    SHELLCHECK_ARCH="aarch64"
+    SHFMT_ARCH="arm64"
+    YQ_ARCH="arm64"
+    ;;
+  armhf)
+    SHELLCHECK_ARCH="armv6hf"
+    SHFMT_ARCH="arm"
+    YQ_ARCH="arm"
+    ;;
+  i386)
+    SHELLCHECK_ARCH=""
+    SHFMT_ARCH="386"
+    YQ_ARCH="386"
+    ;;
+  *)
+    echo "Unsupported architecture for shell tools: $ARCH"
+    exit 1
+    ;;
+esac
+
+# install 'shellcheck' shell script analyser
+if [ -n "$SHELLCHECK_ARCH" ]; then
+  SHELLCHECK_VERSION=$(curl -s "https://api.github.com/repos/koalaman/shellcheck/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
+  curl -Lo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz"
+  tar xf shellcheck.tar.xz --strip-components=1 \
+    "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+  sudo install shellcheck /usr/local/bin/shellcheck
+  rm shellcheck.tar.xz shellcheck
+else
+  # Upstream does not publish a Linux i386 binary.
+  sudo DEBIAN_FRONTEND=noninteractive apt install -y shellcheck
+fi
+
+# install 'shfmt' shell script formatter
+SHFMT_VERSION=$(curl -s "https://api.github.com/repos/mvdan/sh/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
+curl -Lo shfmt "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_${SHFMT_ARCH}"
+sudo install shfmt /usr/local/bin/shfmt
+rm ./shfmt
+
+# install 'jq' command-line JSON processor
+curl -Lo jq "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}"
+sudo install jq /usr/local/bin/jq
+rm ./jq
+
+# install 'yq' command-line YAML processor
+curl -Lo yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${YQ_ARCH}"
+sudo install yq /usr/local/bin/yq
+rm ./yq
+
 # install `dust` as an alternative to `du`
 cargo binstall du-dust --no-confirm
 
@@ -141,9 +198,6 @@ case "$ARCH" in
     ;;
   i386)
     DUF_ARCH="386"
-    ;;
-  ppc64el)
-    DUF_ARCH="ppc64le"
     ;;
   *)
     echo "Unsupported architecture for duf: $ARCH"

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -7,12 +7,12 @@ ARCH=$(dpkg --print-architecture)
 
 # install 'zoxide' tool (this is a faster 'z' tool)
 curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
-if ! grep -qc 'zoxide init' "$shell_rc" ; then
-{
-  echo
-  echo "# Set up 'zoxide' (jump around)"
-  echo "eval \"\$(zoxide init $shell_type)\""
-} >> "$shell_rc"
+if ! grep -qc 'zoxide init' "$shell_rc"; then
+  {
+    echo
+    echo "# Set up 'zoxide' (jump around)"
+    echo "eval \"\$(zoxide init $shell_type)\""
+  } >> "$shell_rc"
 
 fi
 
@@ -52,11 +52,11 @@ rm ./fd.deb
 cargo binstall bob-nvim --no-confirm
 # ensure we can find nvim if installed by bob:
 if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
-{
-  echo
-  echo "# so we can find nvim"
-  echo 'export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"'
-} >> "$shell_rc"
+  {
+    echo
+    echo "# so we can find nvim"
+    echo 'export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"'
+  } >> "$shell_rc"
 fi
 
 # install 'lsplus' as an available `ls` replacement
@@ -65,7 +65,7 @@ cargo binstall lsplus --no-confirm
 # install 'yazi' terminal file manager
 cargo binstall yazi-fm --no-confirm
 if ! grep -Fqc 'function y()' "$shell_rc"; then
-  cat <<'EOF' >> "$shell_rc"
+  cat << 'EOF' >> "$shell_rc"
 
 # Set up 'yazi' with directory changing on exit
 function y() {
@@ -80,10 +80,10 @@ fi
 
 # install 'atuin' shell history
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh \
-  | ATUIN_NO_MODIFY_PATH=1 sh
+  https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh |
+  ATUIN_NO_MODIFY_PATH=1 sh
 if ! grep -Fqc '.atuin/bin/env' "$shell_rc"; then
-  cat <<'EOF' >> "$shell_rc"
+  cat << 'EOF' >> "$shell_rc"
 
 # Add 'atuin' to the path
 . "$HOME/.atuin/bin/env"
@@ -94,7 +94,7 @@ if [ "$shell_type" = "bash" ]; then
     https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh \
     -o "$HOME/.bash-preexec.sh"
   if ! grep -Fqc '.bash-preexec.sh' "$shell_rc"; then
-    cat <<'EOF' >> "$shell_rc"
+    cat << 'EOF' >> "$shell_rc"
 [[ -f "$HOME/.bash-preexec.sh" ]] && source "$HOME/.bash-preexec.sh"
 EOF
   fi
@@ -196,7 +196,7 @@ cargo binstall du-dust --no-confirm
 
 # install 'duf' as an alternative to 'df'
 case "$ARCH" in
-  amd64|arm64)
+  amd64 | arm64)
     DUF_ARCH="$ARCH"
     ;;
   armhf)
@@ -217,10 +217,10 @@ rm ./duf.deb
 
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh | bash
-if ! grep -qc 'direnv hook' "$shell_rc" ; then
-{
-  echo
-  echo "# Set up 'direnv' (environment switcher)"
-  echo "eval \"\$(direnv hook $shell_type)\""
-} >> "$shell_rc"
+if ! grep -qc 'direnv hook' "$shell_rc"; then
+  {
+    echo
+    echo "# Set up 'direnv' (environment switcher)"
+    echo "eval \"\$(direnv hook $shell_type)\""
+  } >> "$shell_rc"
 fi

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -45,11 +45,18 @@ esac
 install_binary_from_url() {
   local component=$1
   local url=$2
-  if ! curl -fLo "$component" "$url" ||
-    ! sudo install "$component" "/usr/local/bin/$component"; then
+  local binary_tmp
+
+  if ! binary_tmp=$(mktemp -t "${component}.XXXXXX"); then
+    record_failed_install "$component"
+    return
+  fi
+
+  if ! curl -fL -o "$binary_tmp" "$url" ||
+    ! sudo install "$binary_tmp" "/usr/local/bin/$component"; then
     record_failed_install "$component"
   fi
-  rm -f -- "./$component"
+  rm -f -- "$binary_tmp"
 }
 
 # install 'zoxide' tool (this is a faster 'z' tool)
@@ -276,12 +283,8 @@ else
 fi
 
 # install 'jq' command-line JSON processor
-if [ "$ARCH_SUPPORTED" = "yes" ]; then
-  install_binary_from_url jq \
-    "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}"
-else
-  record_failed_install jq
-fi
+install_binary_from_url jq \
+  "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}"
 
 # install 'yq' command-line YAML processor
 if [ "$ARCH_SUPPORTED" = "yes" ]; then

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -336,7 +336,7 @@ fpath=("$HOME/.local/share/zsh/site-functions" $fpath)
 if (( ${+functions[compdef]} )); then
   for completion_file in "$HOME/.local/share/zsh/site-functions"/_*(N); do
     completion_function=${completion_file:t}
-    source "$completion_file"
+    autoload -Uz "$completion_function"
     compdef "$completion_function" "${completion_function#_}"
   done
   unset completion_file completion_function
@@ -349,29 +349,53 @@ EOF
 fi
 mkdir -p "$completion_dir"
 
+generate_completion() {
+  local component=$1
+  local output_file=$2
+  local completion_tmp
+  shift 2
+
+  if ! completion_tmp=$(mktemp "$completion_dir/.${component}.XXXXXX"); then
+    record_failed_install "$component completions"
+    return
+  fi
+
+  if "$@" > "$completion_tmp" && [ -s "$completion_tmp" ] &&
+    mv "$completion_tmp" "$output_file"; then
+    return
+  fi
+
+  rm -f -- "$completion_tmp"
+  record_failed_install "$component completions"
+}
+
 if command -v lazygit > /dev/null; then
-  lazygit completion "$shell_type" \
-    > "$completion_dir/${completion_prefix}lazygit"
+  generate_completion lazygit \
+    "$completion_dir/${completion_prefix}lazygit" \
+    lazygit completion "$shell_type"
 fi
 if command -v bob > /dev/null; then
-  bob complete "$shell_type" > "$completion_dir/${completion_prefix}bob"
+  generate_completion bob "$completion_dir/${completion_prefix}bob" \
+    bob complete "$shell_type"
 fi
 if command -v atuin > /dev/null; then
-  atuin gen-completions --shell "$shell_type" \
-    > "$completion_dir/${completion_prefix}atuin"
+  generate_completion atuin "$completion_dir/${completion_prefix}atuin" \
+    atuin gen-completions --shell "$shell_type"
 fi
 if command -v delta > /dev/null; then
-  delta --generate-completion "$shell_type" \
-    > "$completion_dir/${completion_prefix}delta"
+  generate_completion delta "$completion_dir/${completion_prefix}delta" \
+    delta --generate-completion "$shell_type"
 fi
 if command -v xh > /dev/null; then
-  xh --generate "complete-$shell_type" \
-    > "$completion_dir/${completion_prefix}xh"
+  generate_completion xh "$completion_dir/${completion_prefix}xh" \
+    xh --generate "complete-$shell_type"
 fi
 if command -v watchexec > /dev/null; then
-  watchexec --completions "$shell_type" \
-    > "$completion_dir/${completion_prefix}watchexec"
+  generate_completion watchexec \
+    "$completion_dir/${completion_prefix}watchexec" \
+    watchexec --completions "$shell_type"
 fi
 if command -v yq > /dev/null; then
-  yq completion "$shell_type" > "$completion_dir/${completion_prefix}yq"
+  generate_completion yq "$completion_dir/${completion_prefix}yq" \
+    yq completion "$shell_type"
 fi

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -4,58 +4,119 @@
 
 # get this device arch:
 ARCH=$(dpkg --print-architecture)
-failed_installs=()
 
-install_with_cargo_binstall() {
-  local package=$1
-  if ! cargo binstall "$package" --no-confirm; then
-    echo "Warning: failed to install '$package' with cargo-binstall."
-    failed_installs+=("$package")
+# map Debian architecture names to upstream release asset names
+ARCH_SUPPORTED="yes"
+case "$ARCH" in
+  amd64)
+    HYPERFINE_ARCH="amd64"
+    SHELLCHECK_ARCH="x86_64"
+    SHFMT_ARCH="amd64"
+    YQ_ARCH="amd64"
+    DUF_ARCH="amd64"
+    ;;
+  arm64)
+    HYPERFINE_ARCH="arm64"
+    SHELLCHECK_ARCH="aarch64"
+    SHFMT_ARCH="arm64"
+    YQ_ARCH="arm64"
+    DUF_ARCH="arm64"
+    ;;
+  armhf)
+    HYPERFINE_ARCH="armhf"
+    SHELLCHECK_ARCH="armv6hf"
+    SHFMT_ARCH="arm"
+    YQ_ARCH="arm"
+    DUF_ARCH="armv7"
+    ;;
+  i386)
+    HYPERFINE_ARCH="i686"
+    SHELLCHECK_ARCH=""
+    SHFMT_ARCH="386"
+    YQ_ARCH="386"
+    DUF_ARCH="386"
+    ;;
+  *)
+    ARCH_SUPPORTED="no"
+    echo "Warning: no release asset mappings are available for '$ARCH'."
+    ;;
+esac
+
+install_binary_from_url() {
+  local component=$1
+  local url=$2
+  if ! curl -fLo "$component" "$url" ||
+    ! sudo install "$component" "/usr/local/bin/$component"; then
+    record_failed_install "$component"
   fi
+  rm -f -- "./$component"
 }
 
 # install 'zoxide' tool (this is a faster 'z' tool)
-curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
-if ! grep -q 'zoxide init' "$shell_rc"; then
+zoxide_installer_tmp=$(mktemp -t "zoxide-installer.XXXXXX")
+if ! curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh \
+  -o "$zoxide_installer_tmp" ||
+  ! sh "$zoxide_installer_tmp"; then
+  record_failed_install zoxide
+fi
+rm -f -- "$zoxide_installer_tmp"
+if command -v zoxide > /dev/null && ! grep -q 'zoxide init' "$shell_rc"; then
   {
     echo
     echo "# Set up 'zoxide' (jump around)"
     echo "eval \"\$(zoxide init $shell_type)\""
   } >> "$shell_rc"
-
 fi
 
 # install 'fzf' tool (fuzzy finder)
-git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-~/.fzf/install --all
+if { [ ! -x "$HOME/.fzf/install" ] &&
+  ! git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"; } ||
+  ! "$HOME/.fzf/install" --all; then
+  record_failed_install fzf
+fi
 
 # install 'lazygit' tool
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
-tar xf lazygit.tar.gz lazygit
-sudo install lazygit /usr/local/bin
-rm lazygit.tar.gz lazygit
+if ! curl -fLo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" ||
+  ! tar xf lazygit.tar.gz lazygit ||
+  ! sudo install lazygit /usr/local/bin; then
+  record_failed_install lazygit
+fi
+rm -f -- lazygit.tar.gz lazygit
 
 # install 'lazydocker' tool
-curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
+lazydocker_installer_tmp=$(mktemp -t "lazydocker-installer.XXXXXX")
+if ! curl -sfL \
+  https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh \
+  -o "$lazydocker_installer_tmp" ||
+  ! bash "$lazydocker_installer_tmp"; then
+  record_failed_install lazydocker
+fi
+rm -f -- "$lazydocker_installer_tmp"
 
 # install 'bat' tool (cat clone with syntax highlighting)
 BAT_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/bat/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -Lo bat.deb "https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/bat_${BAT_VERSION}_${ARCH}.deb"
-sudo apt install ./bat.deb
-rm ./bat.deb
+if ! curl -fLo bat.deb "https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/bat_${BAT_VERSION}_${ARCH}.deb" ||
+  ! sudo apt install -y ./bat.deb; then
+  record_failed_install bat
+fi
+rm -f -- ./bat.deb
 
 # install 'ripgrep' tool (grep clone with better performance)
 RIPGREP_VERSION=$(curl -s "https://api.github.com/repos/BurntSushi/ripgrep/releases/latest" | grep -Po '"tag_name": "(\K[^"]*)')
-curl -Lo ripgrep.deb "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep_${RIPGREP_VERSION}-1_$ARCH.deb"
-sudo dpkg -i ripgrep.deb
-rm ./ripgrep.deb
+if ! curl -fLo ripgrep.deb "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep_${RIPGREP_VERSION}-1_$ARCH.deb" ||
+  ! sudo dpkg -i ripgrep.deb; then
+  record_failed_install ripgrep
+fi
+rm -f -- ./ripgrep.deb
 
 # install 'fd' tool (find clone with better performance)
 FD_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/fd/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -Lo fd.deb "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/fd-musl_${FD_VERSION}_$ARCH.deb"
-sudo dpkg -i fd.deb
-rm ./fd.deb
+if ! curl -fLo fd.deb "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/fd-musl_${FD_VERSION}_$ARCH.deb" ||
+  ! sudo dpkg -i fd.deb; then
+  record_failed_install fd
+fi
+rm -f -- ./fd.deb
 
 # install bob neovim version manager
 install_with_cargo_binstall bob-nvim
@@ -88,60 +149,92 @@ EOF
 fi
 
 # install 'atuin' shell history
-curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh |
-  ATUIN_NO_MODIFY_PATH=1 sh
-if ! grep -Fq '.atuin/bin/env' "$shell_rc"; then
+atuin_installer_tmp=$(mktemp -t "atuin-installer.XXXXXX")
+atuin_install_failed="no"
+if ! curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh \
+  -o "$atuin_installer_tmp" ||
+  ! ATUIN_NO_MODIFY_PATH=1 sh "$atuin_installer_tmp"; then
+  record_failed_install atuin
+  atuin_install_failed="yes"
+fi
+rm -f -- "$atuin_installer_tmp"
+
+if [ -x "$HOME/.atuin/bin/atuin" ] && [ -f "$HOME/.atuin/bin/env" ]; then
+  export PATH="$HOME/.atuin/bin:$PATH"
+elif [ "$atuin_install_failed" = "no" ]; then
+  record_failed_install atuin
+fi
+
+if command -v atuin > /dev/null &&
+  ! grep -Fq '.atuin/bin/env' "$shell_rc"; then
   cat << 'EOF' >> "$shell_rc"
 
 # Add 'atuin' to the path
 . "$HOME/.atuin/bin/env"
 EOF
 fi
-if [ "$shell_type" = "bash" ]; then
+if command -v atuin > /dev/null && [ "$shell_type" = "bash" ]; then
   bash_preexec_tmp=$(mktemp -t "bash-preexec.XXXXXX")
   if ! curl --proto '=https' --tlsv1.2 -LsSf \
     https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh \
     -o "$bash_preexec_tmp" ||
     ! mv "$bash_preexec_tmp" "$HOME/.bash-preexec.sh"; then
     rm -f -- "$bash_preexec_tmp"
-    echo "Warning: failed to install bash-preexec."
-    failed_installs+=("bash-preexec")
+    record_failed_install bash-preexec
   fi
   if [ -f "$HOME/.bash-preexec.sh" ] &&
     ! grep -Fq '.bash-preexec.sh' "$shell_rc"; then
     cat << 'EOF' >> "$shell_rc"
+
+# Set up bash-preexec for Atuin
 [[ -f "$HOME/.bash-preexec.sh" ]] && source "$HOME/.bash-preexec.sh"
 EOF
   fi
 fi
-if { [ "$shell_type" != "bash" ] || [ -f "$HOME/.bash-preexec.sh" ]; } &&
+if command -v atuin > /dev/null &&
+  { [ "$shell_type" != "bash" ] || [ -f "$HOME/.bash-preexec.sh" ]; } &&
   ! grep -Fq 'atuin init' "$shell_rc"; then
-  printf "eval \"\$(atuin init %s --disable-up-arrow)\"\n" "$shell_type" \
-    >> "$shell_rc"
+  {
+    echo
+    echo "# Set up Atuin shell history"
+    printf "eval \"\$(atuin init %s --disable-up-arrow)\"\n" "$shell_type"
+  } >> "$shell_rc"
 fi
 
 # install 'delta' syntax-highlighting pager
-DELTA_VERSION=$(curl -s "https://api.github.com/repos/dandavison/delta/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
-curl -Lo git-delta.deb "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${ARCH}.deb"
-sudo DEBIAN_FRONTEND=noninteractive apt install -y ./git-delta.deb
-rm ./git-delta.deb
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  DELTA_VERSION=$(curl -s "https://api.github.com/repos/dandavison/delta/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
+  if ! curl -fLo git-delta.deb "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${ARCH}.deb" ||
+    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y ./git-delta.deb; then
+    record_failed_install delta
+  fi
+  rm -f -- ./git-delta.deb
+else
+  record_failed_install delta
+fi
 
 # install 'hyperfine' command-line benchmarking tool
 # Debian reports 32-bit x86 as i386, but hyperfine names its package i686.
-if [ "$ARCH" = "i386" ]; then
-  HYPERFINE_ARCH="i686"
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  HYPERFINE_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/hyperfine/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+  if ! curl -fLo hyperfine.deb "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_${HYPERFINE_ARCH}.deb" ||
+    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y ./hyperfine.deb; then
+    record_failed_install hyperfine
+  fi
+  rm -f -- ./hyperfine.deb
 else
-  HYPERFINE_ARCH="$ARCH"
+  record_failed_install hyperfine
 fi
-HYPERFINE_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/hyperfine/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -Lo hyperfine.deb "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_${HYPERFINE_ARCH}.deb"
-sudo DEBIAN_FRONTEND=noninteractive apt install -y ./hyperfine.deb
-rm ./hyperfine.deb
 
 # install 'xh' HTTP client
-curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh |
-  XH_BINDIR="$HOME/.local/bin" sh
+xh_installer_tmp=$(mktemp -t "xh-installer.XXXXXX")
+if ! curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh \
+  -o "$xh_installer_tmp" ||
+  ! XH_BINDIR="$HOME/.local/bin" sh "$xh_installer_tmp"; then
+  record_failed_install xh
+fi
+rm -f -- "$xh_installer_tmp"
 
 # install 'watchexec' command runner
 install_with_cargo_binstall watchexec-cli
@@ -152,91 +245,75 @@ install_with_cargo_binstall tokei
 # install 'television' fuzzy finder
 install_with_cargo_binstall television
 
-# map Debian architecture names to upstream release asset names
-case "$ARCH" in
-  amd64)
-    SHELLCHECK_ARCH="x86_64"
-    SHFMT_ARCH="amd64"
-    YQ_ARCH="amd64"
-    ;;
-  arm64)
-    SHELLCHECK_ARCH="aarch64"
-    SHFMT_ARCH="arm64"
-    YQ_ARCH="arm64"
-    ;;
-  armhf)
-    SHELLCHECK_ARCH="armv6hf"
-    SHFMT_ARCH="arm"
-    YQ_ARCH="arm"
-    ;;
-  i386)
-    SHELLCHECK_ARCH=""
-    SHFMT_ARCH="386"
-    YQ_ARCH="386"
-    ;;
-  *)
-    echo "Unsupported architecture for shell tools: $ARCH"
-    exit 1
-    ;;
-esac
-
 # install 'shellcheck' shell script analyser
-if [ -n "$SHELLCHECK_ARCH" ]; then
-  SHELLCHECK_VERSION=$(curl -s "https://api.github.com/repos/koalaman/shellcheck/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
-  curl -Lo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz"
-  tar xf shellcheck.tar.xz --strip-components=1 \
-    "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
-  sudo install shellcheck /usr/local/bin/shellcheck
-  rm shellcheck.tar.xz shellcheck
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  if [ -n "$SHELLCHECK_ARCH" ]; then
+    SHELLCHECK_VERSION=$(curl -s "https://api.github.com/repos/koalaman/shellcheck/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
+    if ! curl -fLo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" ||
+      ! tar xf shellcheck.tar.xz --strip-components=1 \
+        "shellcheck-${SHELLCHECK_VERSION}/shellcheck" ||
+      ! sudo install shellcheck /usr/local/bin/shellcheck; then
+      record_failed_install shellcheck
+    fi
+    rm -f -- shellcheck.tar.xz shellcheck
+  else
+    # Upstream does not publish a Linux i386 binary.
+    if ! sudo DEBIAN_FRONTEND=noninteractive apt install -y shellcheck; then
+      record_failed_install shellcheck
+    fi
+  fi
 else
-  # Upstream does not publish a Linux i386 binary.
-  sudo DEBIAN_FRONTEND=noninteractive apt install -y shellcheck
+  record_failed_install shellcheck
 fi
 
 # install 'shfmt' shell script formatter
-SHFMT_VERSION=$(curl -s "https://api.github.com/repos/mvdan/sh/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
-curl -Lo shfmt "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_${SHFMT_ARCH}"
-sudo install shfmt /usr/local/bin/shfmt
-rm ./shfmt
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  SHFMT_VERSION=$(curl -s "https://api.github.com/repos/mvdan/sh/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
+  install_binary_from_url shfmt \
+    "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_${SHFMT_ARCH}"
+else
+  record_failed_install shfmt
+fi
 
 # install 'jq' command-line JSON processor
-curl -Lo jq "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}"
-sudo install jq /usr/local/bin/jq
-rm ./jq
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  install_binary_from_url jq \
+    "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}"
+else
+  record_failed_install jq
+fi
 
 # install 'yq' command-line YAML processor
-curl -Lo yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${YQ_ARCH}"
-sudo install yq /usr/local/bin/yq
-rm ./yq
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  install_binary_from_url yq \
+    "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${YQ_ARCH}"
+else
+  record_failed_install yq
+fi
 
 # install `dust` as an alternative to `du`
 install_with_cargo_binstall du-dust
 
 # install 'duf' as an alternative to 'df'
-case "$ARCH" in
-  amd64 | arm64)
-    DUF_ARCH="$ARCH"
-    ;;
-  armhf)
-    DUF_ARCH="armv7"
-    ;;
-  i386)
-    DUF_ARCH="386"
-    ;;
-  *)
-    echo "Unsupported architecture for duf: $ARCH"
-    exit 1
-    ;;
-esac
-DUF_VERSION=$(curl -s "https://api.github.com/repos/muesli/duf/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -Lo duf.deb "https://github.com/muesli/duf/releases/download/v${DUF_VERSION}/duf_${DUF_VERSION}_linux_${DUF_ARCH}.deb"
-sudo DEBIAN_FRONTEND=noninteractive apt install -y ./duf.deb
-rm ./duf.deb
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  DUF_VERSION=$(curl -s "https://api.github.com/repos/muesli/duf/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+  if ! curl -fLo duf.deb "https://github.com/muesli/duf/releases/download/v${DUF_VERSION}/duf_${DUF_VERSION}_linux_${DUF_ARCH}.deb" ||
+    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y ./duf.deb; then
+    record_failed_install duf
+  fi
+  rm -f -- ./duf.deb
+else
+  record_failed_install duf
+fi
 
 # install 'direnv' tool (environment switcher)
-curl -sfL https://direnv.net/install.sh |
-  bin_path="$HOME/.local/bin" bash
-if ! grep -q 'direnv hook' "$shell_rc"; then
+direnv_installer_tmp=$(mktemp -t "direnv-installer.XXXXXX")
+if ! curl -sfL https://direnv.net/install.sh -o "$direnv_installer_tmp" ||
+  ! bin_path="$HOME/.local/bin" bash "$direnv_installer_tmp"; then
+  record_failed_install direnv
+fi
+rm -f -- "$direnv_installer_tmp"
+if command -v direnv > /dev/null && ! grep -q 'direnv hook' "$shell_rc"; then
   {
     echo
     echo "# Set up 'direnv' (environment switcher)"
@@ -297,10 +374,4 @@ if command -v watchexec > /dev/null; then
 fi
 if command -v yq > /dev/null; then
   yq completion "$shell_type" > "$completion_dir/${completion_prefix}yq"
-fi
-
-if ((${#failed_installs[@]} > 0)); then
-  echo
-  echo "The following optional components could not be installed or updated:"
-  printf ' - %s\n' "${failed_installs[@]}"
 fi

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -8,9 +8,12 @@ ARCH=$(dpkg --print-architecture)
 # install 'zoxide' tool (this is a faster 'z' tool)
 curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
 if ! grep -qc 'zoxide init' "$shell_rc" ; then
-  echo >> "$shell_rc"
-  echo "# Set up 'zoxide' (jump around)" >> "$shell_rc"
-  echo "eval \"\$(zoxide init $shell_type)\"" >> "$shell_rc"
+{
+  echo
+  echo "# Set up 'zoxide' (jump around)"
+  echo "eval \"\$(zoxide init $shell_type)\""
+} >> "$shell_rc"
+
 fi
 
 # install 'fzf' tool (fuzzy finder)
@@ -49,9 +52,11 @@ rm ./fd.deb
 cargo binstall bob-nvim --no-confirm
 # ensure we can find nvim if installed by bob:
 if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
-  echo >> "$shell_rc"
-  echo "# so we can find nvim" >> "$shell_rc"
-  echo 'export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"' >> "$shell_rc"
+{
+  echo
+  echo "# so we can find nvim"
+  echo 'export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"'
+} >> "$shell_rc"
 fi
 
 # install 'lsplus' as an available `ls` replacement
@@ -87,7 +92,9 @@ rm ./duf.deb
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh | bash
 if ! grep -qc 'direnv hook' "$shell_rc" ; then
-  echo >> "$shell_rc"
-  echo "# Set up 'direnv' (environment switcher)" >> "$shell_rc"
-  echo "eval \"\$(direnv hook $shell_type)\"" >> "$shell_rc"
+{
+  echo
+  echo "# Set up 'direnv' (environment switcher)"
+  echo "eval \"\$(direnv hook $shell_type)\""
+} >> "$shell_rc"
 fi

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -226,3 +226,34 @@ if ! grep -qc 'direnv hook' "$shell_rc"; then
     echo "eval \"\$(direnv hook $shell_type)\""
   } >> "$shell_rc"
 fi
+
+# generate shell completions for tools not installed from system packages
+if [ "$shell_type" = "bash" ]; then
+  completion_dir="$HOME/.local/share/bash-completion/completions"
+  completion_prefix=""
+else
+  completion_dir="$HOME/.local/share/zsh/site-functions"
+  completion_prefix="_"
+  if ! grep -Fqc '.local/share/zsh/site-functions' "$shell_rc"; then
+    cat << 'EOF' >> "$shell_rc"
+
+# Load completions for user-installed tools
+fpath=("$HOME/.local/share/zsh/site-functions" $fpath)
+autoload -Uz compinit
+compinit
+EOF
+  fi
+fi
+mkdir -p "$completion_dir"
+
+lazygit completion "$shell_type" \
+  > "$completion_dir/${completion_prefix}lazygit"
+bob complete "$shell_type" > "$completion_dir/${completion_prefix}bob"
+atuin gen-completions --shell "$shell_type" \
+  > "$completion_dir/${completion_prefix}atuin"
+delta --generate-completion "$shell_type" \
+  > "$completion_dir/${completion_prefix}delta"
+xh --generate "complete-$shell_type" > "$completion_dir/${completion_prefix}xh"
+watchexec --completions "$shell_type" \
+  > "$completion_dir/${completion_prefix}watchexec"
+yq completion "$shell_type" > "$completion_dir/${completion_prefix}yq"

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -46,7 +46,7 @@ sudo dpkg -i fd.deb
 rm ./fd.deb
 
 # install bob neovim version manager
-cargo bininstall bob-nvim --no-confirm
+cargo binstall bob-nvim --no-confirm
 # ensure we can find nvim if installed by bob:
 if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
   echo >> "$shell_rc"
@@ -59,6 +59,30 @@ cargo binstall lsplus --no-confirm
 
 # install `dust` as an alternative to `du`
 cargo binstall du-dust --no-confirm
+
+# install 'duf' as an alternative to 'df'
+case "$ARCH" in
+  amd64|arm64)
+    DUF_ARCH="$ARCH"
+    ;;
+  armhf)
+    DUF_ARCH="armv7"
+    ;;
+  i386)
+    DUF_ARCH="386"
+    ;;
+  ppc64el)
+    DUF_ARCH="ppc64le"
+    ;;
+  *)
+    echo "Unsupported architecture for duf: $ARCH"
+    exit 1
+    ;;
+esac
+DUF_VERSION=$(curl -s "https://api.github.com/repos/muesli/duf/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+curl -Lo duf.deb "https://github.com/muesli/duf/releases/download/v${DUF_VERSION}/duf_${DUF_VERSION}_linux_${DUF_ARCH}.deb"
+sudo DEBIAN_FRONTEND=noninteractive apt install -y ./duf.deb
+rm ./duf.deb
 
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh | bash

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -58,12 +58,9 @@ install_binary_from_url() {
 }
 
 # install 'zoxide' tool (this is a faster 'z' tool)
-zoxide_installer_tmp="$install_tmp_dir/zoxide-installer.sh"
-if ! curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh \
-  -o "$zoxide_installer_tmp" ||
-  ! (cd "$install_tmp_dir" && sh "$zoxide_installer_tmp"); then
-  record_failed_install zoxide
-fi
+run_downloaded_installer zoxide \
+  https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh \
+  zoxide-installer.sh sh
 if command -v zoxide > /dev/null && ! grep -q 'zoxide init' "$shell_rc"; then
   {
     echo
@@ -103,13 +100,9 @@ else
 fi
 
 # install 'lazydocker' tool
-lazydocker_installer_tmp="$install_tmp_dir/lazydocker-installer.sh"
-if ! curl -sfL \
+run_downloaded_installer lazydocker \
   https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh \
-  -o "$lazydocker_installer_tmp" ||
-  ! (cd "$install_tmp_dir" && bash "$lazydocker_installer_tmp"); then
-  record_failed_install lazydocker
-fi
+  lazydocker-installer.sh bash
 
 # install 'bat' tool (cat clone with syntax highlighting)
 BAT_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/bat/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
@@ -166,14 +159,9 @@ EOF
 fi
 
 # install 'atuin' shell history
-atuin_installer_tmp="$install_tmp_dir/atuin-installer.sh"
-if ! curl --proto '=https' --tlsv1.2 -LsSf \
+ATUIN_NO_MODIFY_PATH=1 run_downloaded_installer atuin \
   https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh \
-  -o "$atuin_installer_tmp" ||
-  ! (cd "$install_tmp_dir" &&
-    ATUIN_NO_MODIFY_PATH=1 sh "$atuin_installer_tmp"); then
-  record_failed_install atuin
-fi
+  atuin-installer.sh sh
 
 if [ -x "$HOME/.atuin/bin/atuin" ]; then
   export PATH="$HOME/.atuin/bin:$PATH"
@@ -243,13 +231,9 @@ else
 fi
 
 # install 'xh' HTTP client
-xh_installer_tmp="$install_tmp_dir/xh-installer.sh"
-if ! curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh \
-  -o "$xh_installer_tmp" ||
-  ! (cd "$install_tmp_dir" &&
-    XH_BINDIR="$HOME/.local/bin" sh "$xh_installer_tmp"); then
-  record_failed_install xh
-fi
+XH_BINDIR="$HOME/.local/bin" run_downloaded_installer xh \
+  https://raw.githubusercontent.com/ducaale/xh/master/install.sh \
+  xh-installer.sh sh
 
 # install 'watchexec' command runner
 install_with_cargo_binstall watchexec-cli
@@ -319,12 +303,8 @@ else
 fi
 
 # install 'direnv' tool (environment switcher)
-direnv_installer_tmp="$install_tmp_dir/direnv-installer.sh"
-if ! curl -sfL https://direnv.net/install.sh -o "$direnv_installer_tmp" ||
-  ! (cd "$install_tmp_dir" &&
-    bin_path="$HOME/.local/bin" bash "$direnv_installer_tmp"); then
-  record_failed_install direnv
-fi
+bin_path="$HOME/.local/bin" run_downloaded_installer direnv \
+  https://direnv.net/install.sh direnv-installer.sh bash
 if command -v direnv > /dev/null && ! grep -q 'direnv hook' "$shell_rc"; then
   {
     echo

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -4,10 +4,19 @@
 
 # get this device arch:
 ARCH=$(dpkg --print-architecture)
+failed_installs=()
+
+install_with_cargo_binstall() {
+  local package=$1
+  if ! cargo binstall "$package" --no-confirm; then
+    echo "Warning: failed to install '$package' with cargo-binstall."
+    failed_installs+=("$package")
+  fi
+}
 
 # install 'zoxide' tool (this is a faster 'z' tool)
 curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
-if ! grep -qc 'zoxide init' "$shell_rc"; then
+if ! grep -q 'zoxide init' "$shell_rc"; then
   {
     echo
     echo "# Set up 'zoxide' (jump around)"
@@ -49,9 +58,9 @@ sudo dpkg -i fd.deb
 rm ./fd.deb
 
 # install bob neovim version manager
-cargo binstall bob-nvim --no-confirm
+install_with_cargo_binstall bob-nvim
 # ensure we can find nvim if installed by bob:
-if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
+if command -v bob > /dev/null && ! grep -q 'bob/nvim-bin' "$shell_rc"; then
   {
     echo
     echo "# so we can find nvim"
@@ -60,11 +69,11 @@ if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
 fi
 
 # install 'lsplus' as an available `ls` replacement
-cargo binstall lsplus --no-confirm
+install_with_cargo_binstall lsplus
 
 # install 'yazi' terminal file manager
-cargo binstall yazi-fm --no-confirm
-if ! grep -Fqc 'function y()' "$shell_rc"; then
+install_with_cargo_binstall yazi-fm
+if command -v yazi > /dev/null && ! grep -Fq 'function y()' "$shell_rc"; then
   cat << 'EOF' >> "$shell_rc"
 
 # Set up 'yazi' with directory changing on exit
@@ -82,7 +91,7 @@ fi
 curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh |
   ATUIN_NO_MODIFY_PATH=1 sh
-if ! grep -Fqc '.atuin/bin/env' "$shell_rc"; then
+if ! grep -Fq '.atuin/bin/env' "$shell_rc"; then
   cat << 'EOF' >> "$shell_rc"
 
 # Add 'atuin' to the path
@@ -90,16 +99,24 @@ if ! grep -Fqc '.atuin/bin/env' "$shell_rc"; then
 EOF
 fi
 if [ "$shell_type" = "bash" ]; then
-  curl --proto '=https' --tlsv1.2 -LsSf \
+  bash_preexec_tmp=$(mktemp -t "bash-preexec.XXXXXX")
+  if ! curl --proto '=https' --tlsv1.2 -LsSf \
     https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh \
-    -o "$HOME/.bash-preexec.sh"
-  if ! grep -Fqc '.bash-preexec.sh' "$shell_rc"; then
+    -o "$bash_preexec_tmp" ||
+    ! mv "$bash_preexec_tmp" "$HOME/.bash-preexec.sh"; then
+    rm -f -- "$bash_preexec_tmp"
+    echo "Warning: failed to install bash-preexec."
+    failed_installs+=("bash-preexec")
+  fi
+  if [ -f "$HOME/.bash-preexec.sh" ] &&
+    ! grep -Fq '.bash-preexec.sh' "$shell_rc"; then
     cat << 'EOF' >> "$shell_rc"
 [[ -f "$HOME/.bash-preexec.sh" ]] && source "$HOME/.bash-preexec.sh"
 EOF
   fi
 fi
-if ! grep -Fqc 'atuin init' "$shell_rc"; then
+if { [ "$shell_type" != "bash" ] || [ -f "$HOME/.bash-preexec.sh" ]; } &&
+  ! grep -Fq 'atuin init' "$shell_rc"; then
   printf "eval \"\$(atuin init %s --disable-up-arrow)\"\n" "$shell_type" \
     >> "$shell_rc"
 fi
@@ -127,13 +144,13 @@ curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh |
   XH_BINDIR="$HOME/.local/bin" sh
 
 # install 'watchexec' command runner
-cargo binstall watchexec-cli --no-confirm
+install_with_cargo_binstall watchexec-cli
 
 # install 'tokei' code statistics tool
-cargo binstall tokei --no-confirm
+install_with_cargo_binstall tokei
 
 # install 'television' fuzzy finder
-cargo binstall television --no-confirm
+install_with_cargo_binstall television
 
 # map Debian architecture names to upstream release asset names
 case "$ARCH" in
@@ -193,7 +210,7 @@ sudo install yq /usr/local/bin/yq
 rm ./yq
 
 # install `dust` as an alternative to `du`
-cargo binstall du-dust --no-confirm
+install_with_cargo_binstall du-dust
 
 # install 'duf' as an alternative to 'df'
 case "$ARCH" in
@@ -219,7 +236,7 @@ rm ./duf.deb
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh |
   bin_path="$HOME/.local/bin" bash
-if ! grep -qc 'direnv hook' "$shell_rc"; then
+if ! grep -q 'direnv hook' "$shell_rc"; then
   {
     echo
     echo "# Set up 'direnv' (environment switcher)"
@@ -234,26 +251,56 @@ if [ "$shell_type" = "bash" ]; then
 else
   completion_dir="$HOME/.local/share/zsh/site-functions"
   completion_prefix="_"
-  if ! grep -Fqc '.local/share/zsh/site-functions' "$shell_rc"; then
+  if ! grep -Fq '.local/share/zsh/site-functions' "$shell_rc"; then
     cat << 'EOF' >> "$shell_rc"
 
 # Load completions for user-installed tools
 fpath=("$HOME/.local/share/zsh/site-functions" $fpath)
-autoload -Uz compinit
-compinit
+if (( ${+functions[compdef]} )); then
+  for completion_file in "$HOME/.local/share/zsh/site-functions"/_*(N); do
+    completion_function=${completion_file:t}
+    source "$completion_file"
+    compdef "$completion_function" "${completion_function#_}"
+  done
+  unset completion_file completion_function
+else
+  autoload -Uz compinit
+  compinit
+fi
 EOF
   fi
 fi
 mkdir -p "$completion_dir"
 
-lazygit completion "$shell_type" \
-  > "$completion_dir/${completion_prefix}lazygit"
-bob complete "$shell_type" > "$completion_dir/${completion_prefix}bob"
-atuin gen-completions --shell "$shell_type" \
-  > "$completion_dir/${completion_prefix}atuin"
-delta --generate-completion "$shell_type" \
-  > "$completion_dir/${completion_prefix}delta"
-xh --generate "complete-$shell_type" > "$completion_dir/${completion_prefix}xh"
-watchexec --completions "$shell_type" \
-  > "$completion_dir/${completion_prefix}watchexec"
-yq completion "$shell_type" > "$completion_dir/${completion_prefix}yq"
+if command -v lazygit > /dev/null; then
+  lazygit completion "$shell_type" \
+    > "$completion_dir/${completion_prefix}lazygit"
+fi
+if command -v bob > /dev/null; then
+  bob complete "$shell_type" > "$completion_dir/${completion_prefix}bob"
+fi
+if command -v atuin > /dev/null; then
+  atuin gen-completions --shell "$shell_type" \
+    > "$completion_dir/${completion_prefix}atuin"
+fi
+if command -v delta > /dev/null; then
+  delta --generate-completion "$shell_type" \
+    > "$completion_dir/${completion_prefix}delta"
+fi
+if command -v xh > /dev/null; then
+  xh --generate "complete-$shell_type" \
+    > "$completion_dir/${completion_prefix}xh"
+fi
+if command -v watchexec > /dev/null; then
+  watchexec --completions "$shell_type" \
+    > "$completion_dir/${completion_prefix}watchexec"
+fi
+if command -v yq > /dev/null; then
+  yq completion "$shell_type" > "$completion_dir/${completion_prefix}yq"
+fi
+
+if ((${#failed_installs[@]} > 0)); then
+  echo
+  echo "The following optional components could not be installed or updated:"
+  printf ' - %s\n' "${failed_installs[@]}"
+fi

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -62,6 +62,48 @@ fi
 # install 'lsplus' as an available `ls` replacement
 cargo binstall lsplus --no-confirm
 
+# install 'yazi' terminal file manager
+cargo binstall yazi-fm --no-confirm
+if ! grep -Fqc 'function y()' "$shell_rc"; then
+  cat <<'EOF' >> "$shell_rc"
+
+# Set up 'yazi' with directory changing on exit
+function y() {
+  local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
+  command yazi "$@" --cwd-file="$tmp"
+  IFS= read -r -d '' cwd < "$tmp"
+  [ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"
+  command rm -f -- "$tmp"
+}
+EOF
+fi
+
+# install 'atuin' shell history
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh \
+  | ATUIN_NO_MODIFY_PATH=1 sh
+if ! grep -Fqc '.atuin/bin/env' "$shell_rc"; then
+  cat <<'EOF' >> "$shell_rc"
+
+# Add 'atuin' to the path
+. "$HOME/.atuin/bin/env"
+EOF
+fi
+if [ "$shell_type" = "bash" ]; then
+  curl --proto '=https' --tlsv1.2 -LsSf \
+    https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh \
+    -o "$HOME/.bash-preexec.sh"
+  if ! grep -Fqc '.bash-preexec.sh' "$shell_rc"; then
+    cat <<'EOF' >> "$shell_rc"
+[[ -f "$HOME/.bash-preexec.sh" ]] && source "$HOME/.bash-preexec.sh"
+EOF
+  fi
+fi
+if ! grep -Fqc 'atuin init' "$shell_rc"; then
+  printf "eval \"\$(atuin init %s --disable-up-arrow)\"\n" "$shell_type" \
+    >> "$shell_rc"
+fi
+
 # install `dust` as an alternative to `du`
 cargo binstall du-dust --no-confirm
 

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -45,6 +45,8 @@ curl -Lo fd.deb "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/
 sudo dpkg -i fd.deb
 rm ./fd.deb
 
+# install bob neovim version manager
+cargo bininstall bob-nvim --no-confirm
 # ensure we can find nvim if installed by bob:
 if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
   echo >> "$shell_rc"
@@ -52,6 +54,11 @@ if ! grep -qc 'bob/nvim-bin' "$shell_rc"; then
   echo 'export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"' >> "$shell_rc"
 fi
 
+# install 'lsplus' as an available `ls` replacement
+cargo binstall lsplus --no-confirm
+
+# install `dust` as an alternative to `du`
+cargo binstall du-dust --no-confirm
 
 # install 'direnv' tool (environment switcher)
 curl -sfL https://direnv.net/install.sh | bash

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -9,6 +9,7 @@ ARCH=$(dpkg --print-architecture)
 ARCH_SUPPORTED="yes"
 case "$ARCH" in
   amd64)
+    LAZYGIT_ARCH="x86_64"
     HYPERFINE_ARCH="amd64"
     SHELLCHECK_ARCH="x86_64"
     SHFMT_ARCH="amd64"
@@ -16,6 +17,7 @@ case "$ARCH" in
     DUF_ARCH="amd64"
     ;;
   arm64)
+    LAZYGIT_ARCH="arm64"
     HYPERFINE_ARCH="arm64"
     SHELLCHECK_ARCH="aarch64"
     SHFMT_ARCH="arm64"
@@ -23,6 +25,7 @@ case "$ARCH" in
     DUF_ARCH="arm64"
     ;;
   armhf)
+    LAZYGIT_ARCH="armv6"
     HYPERFINE_ARCH="armhf"
     SHELLCHECK_ARCH="armv6hf"
     SHFMT_ARCH="arm"
@@ -30,6 +33,7 @@ case "$ARCH" in
     DUF_ARCH="armv7"
     ;;
   i386)
+    LAZYGIT_ARCH="32-bit"
     HYPERFINE_ARCH="i686"
     SHELLCHECK_ARCH=""
     SHFMT_ARCH="386"
@@ -85,12 +89,16 @@ if [ "$fzf_install_failed" = "yes" ]; then
 fi
 
 # install 'lazygit' tool
-LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-lazygit_archive="$install_tmp_dir/lazygit.tar.gz"
-lazygit_binary="$install_tmp_dir/lazygit"
-if ! curl -fLo "$lazygit_archive" "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" ||
-  ! tar -xf "$lazygit_archive" -C "$install_tmp_dir" lazygit ||
-  ! sudo install "$lazygit_binary" /usr/local/bin; then
+if [ "$ARCH_SUPPORTED" = "yes" ]; then
+  LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+  lazygit_archive="$install_tmp_dir/lazygit.tar.gz"
+  lazygit_binary="$install_tmp_dir/lazygit"
+  if ! curl -fLo "$lazygit_archive" "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_linux_${LAZYGIT_ARCH}.tar.gz" ||
+    ! tar -xf "$lazygit_archive" -C "$install_tmp_dir" lazygit ||
+    ! sudo install "$lazygit_binary" /usr/local/bin; then
+    record_failed_install lazygit
+  fi
+else
   record_failed_install lazygit
 fi
 

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -76,13 +76,18 @@ if command -v zoxide > /dev/null && ! grep -q 'zoxide init' "$shell_rc"; then
 fi
 
 # install 'fzf' tool (fuzzy finder)
+fzf_install_failed="no"
 if [ -x "$HOME/.fzf/install" ]; then
-  if ! git -C "$HOME/.fzf" pull --ff-only ||
-    ! "$HOME/.fzf/install" --all; then
-    record_failed_install fzf
+  if ! git -C "$HOME/.fzf" pull --ff-only; then
+    fzf_install_failed="yes"
   fi
-elif ! git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf" ||
-  ! "$HOME/.fzf/install" --all; then
+elif ! git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"; then
+  fzf_install_failed="yes"
+fi
+if [ ! -x "$HOME/.fzf/install" ] || ! "$HOME/.fzf/install" --all; then
+  fzf_install_failed="yes"
+fi
+if [ "$fzf_install_failed" = "yes" ]; then
   record_failed_install fzf
 fi
 

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -123,7 +123,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y ./hyperfine.deb
 rm ./hyperfine.deb
 
 # install 'xh' HTTP client
-curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | sh
+curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh |
+  XH_BINDIR="$HOME/.local/bin" sh
 
 # install 'watchexec' command runner
 cargo binstall watchexec-cli --no-confirm
@@ -216,7 +217,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y ./duf.deb
 rm ./duf.deb
 
 # install 'direnv' tool (environment switcher)
-curl -sfL https://direnv.net/install.sh | bash
+curl -sfL https://direnv.net/install.sh |
+  bin_path="$HOME/.local/bin" bash
 if ! grep -qc 'direnv hook' "$shell_rc"; then
   {
     echo

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -104,6 +104,30 @@ if ! grep -Fqc 'atuin init' "$shell_rc"; then
     >> "$shell_rc"
 fi
 
+# install 'delta' syntax-highlighting pager
+DELTA_VERSION=$(curl -s "https://api.github.com/repos/dandavison/delta/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
+curl -Lo git-delta.deb "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${ARCH}.deb"
+sudo DEBIAN_FRONTEND=noninteractive apt install -y ./git-delta.deb
+rm ./git-delta.deb
+
+# install 'hyperfine' command-line benchmarking tool
+# Debian reports 32-bit x86 as i386, but hyperfine names its package i686.
+if [ "$ARCH" = "i386" ]; then
+  HYPERFINE_ARCH="i686"
+else
+  HYPERFINE_ARCH="$ARCH"
+fi
+HYPERFINE_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/hyperfine/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+curl -Lo hyperfine.deb "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_${HYPERFINE_ARCH}.deb"
+sudo DEBIAN_FRONTEND=noninteractive apt install -y ./hyperfine.deb
+rm ./hyperfine.deb
+
+# install 'xh' HTTP client
+curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | sh
+
+# install 'watchexec' command runner
+cargo binstall watchexec-cli --no-confirm
+
 # install `dust` as an alternative to `du`
 cargo binstall du-dust --no-confirm
 

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -166,28 +166,26 @@ fi
 
 # install 'atuin' shell history
 atuin_installer_tmp=$(mktemp -t "atuin-installer.XXXXXX")
-atuin_install_failed="no"
 if ! curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh \
   -o "$atuin_installer_tmp" ||
   ! ATUIN_NO_MODIFY_PATH=1 sh "$atuin_installer_tmp"; then
   record_failed_install atuin
-  atuin_install_failed="yes"
 fi
 rm -f -- "$atuin_installer_tmp"
 
-if [ -x "$HOME/.atuin/bin/atuin" ] && [ -f "$HOME/.atuin/bin/env" ]; then
+if [ -x "$HOME/.atuin/bin/atuin" ]; then
   export PATH="$HOME/.atuin/bin:$PATH"
-elif [ "$atuin_install_failed" = "no" ]; then
+else
   record_failed_install atuin
 fi
 
 if command -v atuin > /dev/null &&
-  ! grep -Fq '.atuin/bin/env' "$shell_rc"; then
+  ! grep -Fq 'export PATH="$HOME/.atuin/bin:$PATH"' "$shell_rc"; then
   cat << 'EOF' >> "$shell_rc"
 
 # Add 'atuin' to the path
-. "$HOME/.atuin/bin/env"
+export PATH="$HOME/.atuin/bin:$PATH"
 EOF
 fi
 if command -v atuin > /dev/null && [ "$shell_type" = "bash" ]; then

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -128,6 +128,12 @@ curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | sh
 # install 'watchexec' command runner
 cargo binstall watchexec-cli --no-confirm
 
+# install 'tokei' code statistics tool
+cargo binstall tokei --no-confirm
+
+# install 'television' fuzzy finder
+cargo binstall television --no-confirm
+
 # map Debian architecture names to upstream release asset names
 case "$ARCH" in
   amd64)

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -76,8 +76,12 @@ if command -v zoxide > /dev/null && ! grep -q 'zoxide init' "$shell_rc"; then
 fi
 
 # install 'fzf' tool (fuzzy finder)
-if { [ ! -x "$HOME/.fzf/install" ] &&
-  ! git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"; } ||
+if [ -x "$HOME/.fzf/install" ]; then
+  if ! git -C "$HOME/.fzf" pull --ff-only ||
+    ! "$HOME/.fzf/install" --all; then
+    record_failed_install fzf
+  fi
+elif ! git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf" ||
   ! "$HOME/.fzf/install" --all; then
   record_failed_install fzf
 fi

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -45,28 +45,21 @@ esac
 install_binary_from_url() {
   local component=$1
   local url=$2
-  local binary_tmp
-
-  if ! binary_tmp=$(mktemp -t "${component}.XXXXXX"); then
-    record_failed_install "$component"
-    return
-  fi
+  local binary_tmp="$install_tmp_dir/$component"
 
   if ! curl -fL -o "$binary_tmp" "$url" ||
     ! sudo install "$binary_tmp" "/usr/local/bin/$component"; then
     record_failed_install "$component"
   fi
-  rm -f -- "$binary_tmp"
 }
 
 # install 'zoxide' tool (this is a faster 'z' tool)
-zoxide_installer_tmp=$(mktemp -t "zoxide-installer.XXXXXX")
+zoxide_installer_tmp="$install_tmp_dir/zoxide-installer.sh"
 if ! curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh \
   -o "$zoxide_installer_tmp" ||
-  ! sh "$zoxide_installer_tmp"; then
+  ! (cd "$install_tmp_dir" && sh "$zoxide_installer_tmp"); then
   record_failed_install zoxide
 fi
-rm -f -- "$zoxide_installer_tmp"
 if command -v zoxide > /dev/null && ! grep -q 'zoxide init' "$shell_rc"; then
   {
     echo
@@ -93,46 +86,46 @@ fi
 
 # install 'lazygit' tool
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-if ! curl -fLo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" ||
-  ! tar xf lazygit.tar.gz lazygit ||
-  ! sudo install lazygit /usr/local/bin; then
+lazygit_archive="$install_tmp_dir/lazygit.tar.gz"
+lazygit_binary="$install_tmp_dir/lazygit"
+if ! curl -fLo "$lazygit_archive" "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" ||
+  ! tar -xf "$lazygit_archive" -C "$install_tmp_dir" lazygit ||
+  ! sudo install "$lazygit_binary" /usr/local/bin; then
   record_failed_install lazygit
 fi
-rm -f -- lazygit.tar.gz lazygit
 
 # install 'lazydocker' tool
-lazydocker_installer_tmp=$(mktemp -t "lazydocker-installer.XXXXXX")
+lazydocker_installer_tmp="$install_tmp_dir/lazydocker-installer.sh"
 if ! curl -sfL \
   https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh \
   -o "$lazydocker_installer_tmp" ||
-  ! bash "$lazydocker_installer_tmp"; then
+  ! (cd "$install_tmp_dir" && bash "$lazydocker_installer_tmp"); then
   record_failed_install lazydocker
 fi
-rm -f -- "$lazydocker_installer_tmp"
 
 # install 'bat' tool (cat clone with syntax highlighting)
 BAT_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/bat/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-if ! curl -fLo bat.deb "https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/bat_${BAT_VERSION}_${ARCH}.deb" ||
-  ! sudo apt install -y ./bat.deb; then
+bat_package="$install_tmp_dir/bat.deb"
+if ! curl -fLo "$bat_package" "https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/bat_${BAT_VERSION}_${ARCH}.deb" ||
+  ! sudo apt install -y "$bat_package"; then
   record_failed_install bat
 fi
-rm -f -- ./bat.deb
 
 # install 'ripgrep' tool (grep clone with better performance)
 RIPGREP_VERSION=$(curl -s "https://api.github.com/repos/BurntSushi/ripgrep/releases/latest" | grep -Po '"tag_name": "(\K[^"]*)')
-if ! curl -fLo ripgrep.deb "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep_${RIPGREP_VERSION}-1_$ARCH.deb" ||
-  ! sudo dpkg -i ripgrep.deb; then
+ripgrep_package="$install_tmp_dir/ripgrep.deb"
+if ! curl -fLo "$ripgrep_package" "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep_${RIPGREP_VERSION}-1_$ARCH.deb" ||
+  ! sudo dpkg -i "$ripgrep_package"; then
   record_failed_install ripgrep
 fi
-rm -f -- ./ripgrep.deb
 
 # install 'fd' tool (find clone with better performance)
 FD_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/fd/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-if ! curl -fLo fd.deb "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/fd-musl_${FD_VERSION}_$ARCH.deb" ||
-  ! sudo dpkg -i fd.deb; then
+fd_package="$install_tmp_dir/fd.deb"
+if ! curl -fLo "$fd_package" "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/fd-musl_${FD_VERSION}_$ARCH.deb" ||
+  ! sudo dpkg -i "$fd_package"; then
   record_failed_install fd
 fi
-rm -f -- ./fd.deb
 
 # install bob neovim version manager
 install_with_cargo_binstall bob-nvim
@@ -165,14 +158,14 @@ EOF
 fi
 
 # install 'atuin' shell history
-atuin_installer_tmp=$(mktemp -t "atuin-installer.XXXXXX")
+atuin_installer_tmp="$install_tmp_dir/atuin-installer.sh"
 if ! curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh \
   -o "$atuin_installer_tmp" ||
-  ! ATUIN_NO_MODIFY_PATH=1 sh "$atuin_installer_tmp"; then
+  ! (cd "$install_tmp_dir" &&
+    ATUIN_NO_MODIFY_PATH=1 sh "$atuin_installer_tmp"); then
   record_failed_install atuin
 fi
-rm -f -- "$atuin_installer_tmp"
 
 if [ -x "$HOME/.atuin/bin/atuin" ]; then
   export PATH="$HOME/.atuin/bin:$PATH"
@@ -189,7 +182,7 @@ export PATH="$HOME/.atuin/bin:$PATH"
 EOF
 fi
 if command -v atuin > /dev/null && [ "$shell_type" = "bash" ]; then
-  bash_preexec_tmp=$(mktemp -t "bash-preexec.XXXXXX")
+  bash_preexec_tmp="$install_tmp_dir/bash-preexec.sh"
   if ! curl --proto '=https' --tlsv1.2 -LsSf \
     https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh \
     -o "$bash_preexec_tmp" ||
@@ -219,11 +212,11 @@ fi
 # install 'delta' syntax-highlighting pager
 if [ "$ARCH_SUPPORTED" = "yes" ]; then
   DELTA_VERSION=$(curl -s "https://api.github.com/repos/dandavison/delta/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
-  if ! curl -fLo git-delta.deb "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${ARCH}.deb" ||
-    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y ./git-delta.deb; then
+  delta_package="$install_tmp_dir/git-delta.deb"
+  if ! curl -fLo "$delta_package" "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${ARCH}.deb" ||
+    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y "$delta_package"; then
     record_failed_install delta
   fi
-  rm -f -- ./git-delta.deb
 else
   record_failed_install delta
 fi
@@ -232,23 +225,23 @@ fi
 # Debian reports 32-bit x86 as i386, but hyperfine names its package i686.
 if [ "$ARCH_SUPPORTED" = "yes" ]; then
   HYPERFINE_VERSION=$(curl -s "https://api.github.com/repos/sharkdp/hyperfine/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-  if ! curl -fLo hyperfine.deb "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_${HYPERFINE_ARCH}.deb" ||
-    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y ./hyperfine.deb; then
+  hyperfine_package="$install_tmp_dir/hyperfine.deb"
+  if ! curl -fLo "$hyperfine_package" "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/hyperfine_${HYPERFINE_VERSION}_${HYPERFINE_ARCH}.deb" ||
+    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y "$hyperfine_package"; then
     record_failed_install hyperfine
   fi
-  rm -f -- ./hyperfine.deb
 else
   record_failed_install hyperfine
 fi
 
 # install 'xh' HTTP client
-xh_installer_tmp=$(mktemp -t "xh-installer.XXXXXX")
+xh_installer_tmp="$install_tmp_dir/xh-installer.sh"
 if ! curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh \
   -o "$xh_installer_tmp" ||
-  ! XH_BINDIR="$HOME/.local/bin" sh "$xh_installer_tmp"; then
+  ! (cd "$install_tmp_dir" &&
+    XH_BINDIR="$HOME/.local/bin" sh "$xh_installer_tmp"); then
   record_failed_install xh
 fi
-rm -f -- "$xh_installer_tmp"
 
 # install 'watchexec' command runner
 install_with_cargo_binstall watchexec-cli
@@ -263,13 +256,14 @@ install_with_cargo_binstall television
 if [ "$ARCH_SUPPORTED" = "yes" ]; then
   if [ -n "$SHELLCHECK_ARCH" ]; then
     SHELLCHECK_VERSION=$(curl -s "https://api.github.com/repos/koalaman/shellcheck/releases/latest" | grep -Po '"tag_name": "\K[^"]*')
-    if ! curl -fLo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" ||
-      ! tar xf shellcheck.tar.xz --strip-components=1 \
+    shellcheck_archive="$install_tmp_dir/shellcheck.tar.xz"
+    shellcheck_binary="$install_tmp_dir/shellcheck"
+    if ! curl -fLo "$shellcheck_archive" "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" ||
+      ! tar -xf "$shellcheck_archive" -C "$install_tmp_dir" --strip-components=1 \
         "shellcheck-${SHELLCHECK_VERSION}/shellcheck" ||
-      ! sudo install shellcheck /usr/local/bin/shellcheck; then
+      ! sudo install "$shellcheck_binary" /usr/local/bin/shellcheck; then
       record_failed_install shellcheck
     fi
-    rm -f -- shellcheck.tar.xz shellcheck
   else
     # Upstream does not publish a Linux i386 binary.
     if ! sudo DEBIAN_FRONTEND=noninteractive apt install -y shellcheck; then
@@ -307,22 +301,22 @@ install_with_cargo_binstall du-dust
 # install 'duf' as an alternative to 'df'
 if [ "$ARCH_SUPPORTED" = "yes" ]; then
   DUF_VERSION=$(curl -s "https://api.github.com/repos/muesli/duf/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-  if ! curl -fLo duf.deb "https://github.com/muesli/duf/releases/download/v${DUF_VERSION}/duf_${DUF_VERSION}_linux_${DUF_ARCH}.deb" ||
-    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y ./duf.deb; then
+  duf_package="$install_tmp_dir/duf.deb"
+  if ! curl -fLo "$duf_package" "https://github.com/muesli/duf/releases/download/v${DUF_VERSION}/duf_${DUF_VERSION}_linux_${DUF_ARCH}.deb" ||
+    ! sudo DEBIAN_FRONTEND=noninteractive apt install -y "$duf_package"; then
     record_failed_install duf
   fi
-  rm -f -- ./duf.deb
 else
   record_failed_install duf
 fi
 
 # install 'direnv' tool (environment switcher)
-direnv_installer_tmp=$(mktemp -t "direnv-installer.XXXXXX")
+direnv_installer_tmp="$install_tmp_dir/direnv-installer.sh"
 if ! curl -sfL https://direnv.net/install.sh -o "$direnv_installer_tmp" ||
-  ! bin_path="$HOME/.local/bin" bash "$direnv_installer_tmp"; then
+  ! (cd "$install_tmp_dir" &&
+    bin_path="$HOME/.local/bin" bash "$direnv_installer_tmp"); then
   record_failed_install direnv
 fi
-rm -f -- "$direnv_installer_tmp"
 if command -v direnv > /dev/null && ! grep -q 'direnv hook' "$shell_rc"; then
   {
     echo

--- a/modules/extras.sh
+++ b/modules/extras.sh
@@ -348,7 +348,11 @@ fpath=("$HOME/.local/share/zsh/site-functions" $fpath)
 if (( ${+functions[compdef]} )); then
   for completion_file in "$HOME/.local/share/zsh/site-functions"/_*(N); do
     completion_function=${completion_file:t}
-    autoload -Uz "$completion_function"
+    if [[ $completion_function = "_lazygit" ]]; then
+      source "$completion_file"
+    else
+      autoload -Uz "$completion_function"
+    fi
     compdef "$completion_function" "${completion_function#_}"
   done
   unset completion_file completion_function

--- a/modules/nginx-php-pgsql.sh
+++ b/modules/nginx-php-pgsql.sh
@@ -23,9 +23,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.5 php8.5-cli
 
 # their php 8.5 equivalents ...
 sudo DEBIAN_FRONTEND=noninteractive apt install -y php8.5-common php8.5-mysql php8.5-xml php8.5-xmlrpc \
-                    php8.5-curl php8.5-gd php8.5-imagick php8.5-cli php8.5-dev \
-                    php8.5-imap php8.5-mbstring php8.5-soap \
-                    php8.5-zip php8.5-intl php8.5-pgsql
+  php8.5-curl php8.5-gd php8.5-imagick php8.5-cli php8.5-dev \
+  php8.5-imap php8.5-mbstring php8.5-soap \
+  php8.5-zip php8.5-intl php8.5-pgsql
 
 # make sure we are using 8.1 by default
 sudo update-alternatives --set php /usr/bin/php8.5

--- a/modules/nginx-php-pgsql.sh
+++ b/modules/nginx-php-pgsql.sh
@@ -4,11 +4,11 @@
 # plus php8.5 itself. we already installed all the required ppa's etc in the
 # packages/updates so lets just install
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Nginx and Postgresql.                            |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 sudo DEBIAN_FRONTEND=noninteractive apt install -y nginx nginx-extras php8.5-fpm postgresql-18
 

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -2,11 +2,11 @@
 # node.sh
 # Install nvm, the latest LTS version of Node and the latest actual version of Node..
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Latest Node and the LTS (default).               |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 echo "## Setting up NVM (Node Version Manager) ##"
 echo >> "$shell_rc"

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -15,7 +15,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
 
 NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 export NVM_DIR
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"                   # This loads nvm
 [[ -r $NVM_DIR/bash_completion ]] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
 
 # set up some default packages to always install - these 2 allow the use of a

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -11,7 +11,7 @@ echo
 echo "## Setting up NVM (Node Version Manager) ##"
 echo >> "$shell_rc"
 echo "# Set up NVM" >> "$shell_rc"
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
 
 NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 export NVM_DIR

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -14,7 +14,7 @@ echo "# Set up NVM" >> "$shell_rc"
 if ! run_downloaded_installer nvm \
   https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh \
   nvm-installer.sh bash; then
-  return
+  return 1
 fi
 
 NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"

--- a/modules/node.sh
+++ b/modules/node.sh
@@ -11,7 +11,11 @@ echo
 echo "## Setting up NVM (Node Version Manager) ##"
 echo >> "$shell_rc"
 echo "# Set up NVM" >> "$shell_rc"
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
+if ! run_downloaded_installer nvm \
+  https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh \
+  nvm-installer.sh bash; then
+  return
+fi
 
 NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 export NVM_DIR

--- a/modules/packages.sh
+++ b/modules/packages.sh
@@ -2,11 +2,11 @@
 # packages.sh
 # make sure we have the required libraries and tools already installed before starting.
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing More packages that will be needed later.         |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 # now install some important libraries for the next stages...
 sudo DEBIAN_FRONTEND=noninteractive apt install -y build-essential gettext \

--- a/modules/packages.sh
+++ b/modules/packages.sh
@@ -23,6 +23,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y nano htop openssh-server open
 # install winbind and its support lib to ping WINS hosts
 sudo DEBIAN_FRONTEND=noninteractive apt install -y winbind libnss-winbind
 # need to append to the /etc/nsswitch.conf file to enable if not already done ...
-if ! grep -qc 'wins' /etc/nsswitch.conf; then
+if ! grep -q 'wins' /etc/nsswitch.conf; then
   sudo sed -i '/hosts:/ s/$/ wins/' /etc/nsswitch.conf
 fi

--- a/modules/packages.sh
+++ b/modules/packages.sh
@@ -10,12 +10,12 @@ echo
 
 # now install some important libraries for the next stages...
 sudo DEBIAN_FRONTEND=noninteractive apt install -y build-essential gettext \
-                    libssl-dev libreadline-dev zlib1g-dev sqlite3 \
-                    libsqlite3-dev libbz2-dev libxml2-dev libdb-dev ccache \
-                    libffi-dev libpq-dev mcrypt liblzma-dev lzma \
-                    libncurses5-dev xz-utils libxmlsec1-dev tk-dev llvm \
-                    libicu-dev libcurl4-openssl-dev checkinstall libyaml-dev \
-                    terminator lld gh clang nfs-common file
+  libssl-dev libreadline-dev zlib1g-dev sqlite3 \
+  libsqlite3-dev libbz2-dev libxml2-dev libdb-dev ccache \
+  libffi-dev libpq-dev mcrypt liblzma-dev lzma \
+  libncurses5-dev xz-utils libxmlsec1-dev tk-dev llvm \
+  libicu-dev libcurl4-openssl-dev checkinstall libyaml-dev \
+  terminator lld gh clang nfs-common file
 
 # install some 'nice to have' that are missing from very mininal images...
 sudo DEBIAN_FRONTEND=noninteractive apt install -y nano htop openssh-server openssh-client
@@ -23,6 +23,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y nano htop openssh-server open
 # install winbind and its support lib to ping WINS hosts
 sudo DEBIAN_FRONTEND=noninteractive apt install -y winbind libnss-winbind
 # need to append to the /etc/nsswitch.conf file to enable if not already done ...
-if ! grep -qc 'wins' /etc/nsswitch.conf ; then
+if ! grep -qc 'wins' /etc/nsswitch.conf; then
   sudo sed -i '/hosts:/ s/$/ wins/' /etc/nsswitch.conf
 fi

--- a/modules/packages.sh
+++ b/modules/packages.sh
@@ -15,7 +15,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y build-essential gettext \
                     libffi-dev libpq-dev mcrypt liblzma-dev lzma \
                     libncurses5-dev xz-utils libxmlsec1-dev tk-dev llvm \
                     libicu-dev libcurl4-openssl-dev checkinstall libyaml-dev \
-                    terminator lld gh clang nfs-common
+                    terminator lld gh clang nfs-common file
 
 # install some 'nice to have' that are missing from very mininal images...
 sudo DEBIAN_FRONTEND=noninteractive apt install -y nano htop openssh-server openssh-client

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -2,11 +2,11 @@
 # perl.sh
 # install Perl using Perlbrew and set up cpan etc
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Perl.                                            |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 \curl -L https://install.perlbrew.pl | bash
 if ! grep -qc 'perl5/perlbrew/etc/bashrc' "$shell_rc" ; then

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -9,12 +9,12 @@ echo "---------------------------------------------------------------"
 echo
 
 \curl -L https://install.perlbrew.pl | bash
-if ! grep -qc 'perl5/perlbrew/etc/bashrc' "$shell_rc" ; then
+if ! grep -qc 'perl5/perlbrew/etc/bashrc' "$shell_rc"; then
   echo "## Adding Perlbrew to $shell_rc ##"
   {
-  echo
-  echo "# Set up Perlbrew"
-  echo 'source "$HOME/perl5/perlbrew/etc/bashrc"'
+    echo
+    echo "# Set up Perlbrew"
+    echo 'source "$HOME/perl5/perlbrew/etc/bashrc"'
   } >> "$shell_rc"
 fi
 # source perlbrew setup so we can use in this shell...
@@ -25,9 +25,25 @@ perlbrew install perl-5.44.0
 perlbrew switch perl-5.44.0
 perlbrew install-cpanm
 # set up some cpan configuration
-(echo y; echo o conf auto_commit 1; echo o conf yaml_module YAML::XS; echo o conf use_sqlite yes; echo o conf commit) | cpan
-(echo o conf prerequisites_policy follow; echo o conf build_requires_install_policy yes; echo o conf commit) | cpan
-(echo o conf colorize_output yes; echo o conf colorize_print bold white on_black; echo o conf colorize_warn bold red on_black; echo o conf colorize_debug green on_black; echo o conf commit) | cpan
+(
+  echo y
+  echo o conf auto_commit 1
+  echo o conf yaml_module YAML::XS
+  echo o conf use_sqlite yes
+  echo o conf commit
+) | cpan
+(
+  echo o conf prerequisites_policy follow
+  echo o conf build_requires_install_policy yes
+  echo o conf commit
+) | cpan
+(
+  echo o conf colorize_output yes
+  echo o conf colorize_print bold white on_black
+  echo o conf colorize_warn bold red on_black
+  echo o conf colorize_debug green on_black
+  echo o conf commit
+) | cpan
 # now install useful modules for CPAN...
 cpanm Term::ReadLine::Perl --notest # we install this separately and with no tests so it will not timeout on unattended installs. Ohterwise may crash the script.
 cpanm CPAN Term::ReadKey YAML YAML::XS LWP CPAN::SQLite App::cpanoutdated Log::Log4perl XML::LibXML Text::Glob Neovim::Ext App::cpanminus

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -46,7 +46,9 @@ perlbrew install-cpanm
 ) | cpan
 # now install useful modules for CPAN...
 cpanm Term::ReadLine::Perl --notest # we install this separately and with no tests so it will not timeout on unattended installs. Ohterwise may crash the script.
-cpanm CPAN Term::ReadKey YAML YAML::XS LWP CPAN::SQLite App::cpanoutdated Log::Log4perl XML::LibXML Text::Glob Neovim::Ext App::cpanminus
+cpanm CPAN Term::ReadKey YAML YAML::XS LWP CPAN::SQLite App::cpanoutdated Log::Log4perl XML::LibXML Text::Glob App::cpanminus
+# Its test suite downloads an obsolete Neovim nightly asset.
+cpanm Neovim::Ext --notest
 # Upgrade any modules that need it...
 echo "-> running 'cpan-outdated' on Perl modules...."
 cpan-outdated -p | cpanm

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -9,7 +9,7 @@ echo "---------------------------------------------------------------"
 echo
 
 \curl -L https://install.perlbrew.pl | bash
-if ! grep -qc 'perl5/perlbrew/etc/bashrc' "$shell_rc"; then
+if ! grep -q 'perl5/perlbrew/etc/bashrc' "$shell_rc"; then
   echo "## Adding Perlbrew to $shell_rc ##"
   {
     echo

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -8,7 +8,10 @@ echo "| Installing Perl.                                            |"
 echo "---------------------------------------------------------------"
 echo
 
-\curl -L https://install.perlbrew.pl | bash
+if ! run_downloaded_installer perlbrew https://install.perlbrew.pl \
+  perlbrew-installer.sh bash; then
+  return
+fi
 if ! grep -q 'perl5/perlbrew/etc/bashrc' "$shell_rc"; then
   echo "## Adding Perlbrew to $shell_rc ##"
   {

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -11,16 +11,18 @@ echo
 \curl -L https://install.perlbrew.pl | bash
 if ! grep -qc 'perl5/perlbrew/etc/bashrc' "$shell_rc" ; then
   echo "## Adding Perlbrew to $shell_rc ##"
-  echo >> "$shell_rc"
-  echo "# Set up Perlbrew" >> "$shell_rc"
-  echo 'source "$HOME/perl5/perlbrew/etc/bashrc"' >> "$shell_rc"
+  {
+  echo
+  echo "# Set up Perlbrew"
+  echo 'source "$HOME/perl5/perlbrew/etc/bashrc"'
+  } >> "$shell_rc"
 fi
 # source perlbrew setup so we can use in this shell...
 source "$HOME/perl5/perlbrew/etc/bashrc"
 
 # install perl and select it...
-perlbrew install perl-5.42.2
-perlbrew switch perl-5.42.2
+perlbrew install perl-5.44.0
+perlbrew switch perl-5.44.0
 perlbrew install-cpanm
 # set up some cpan configuration
 (echo y; echo o conf auto_commit 1; echo o conf yaml_module YAML::XS; echo o conf use_sqlite yes; echo o conf commit) | cpan

--- a/modules/perl.sh
+++ b/modules/perl.sh
@@ -10,7 +10,7 @@ echo
 
 if ! run_downloaded_installer perlbrew https://install.perlbrew.pl \
   perlbrew-installer.sh bash; then
-  return
+  return 1
 fi
 if ! grep -q 'perl5/perlbrew/etc/bashrc' "$shell_rc"; then
   echo "## Adding Perlbrew to $shell_rc ##"

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -3,11 +3,11 @@
 # 'uv' and 'Poetry' for dependency management and 'pipx' for managing global
 # python packages. Python 2 is no longer installed by default, but can be
 # installed using 'pyenv' if needed.
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Python 3, uv, Poetry and PipX.                   |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 # we still install pyenv, though I now tend to use `uv` for python version
 # management too. Pyenv is still handy to have an updated global version
@@ -30,12 +30,14 @@ EOF
 
 if ! grep -qc 'pyenv init' "$shell_rc" ; then
   echo "## Adding pyenv to $shell_rc ##"
-  echo >> "$shell_rc"
-  echo "# Set up Pyenv" >> "$shell_rc"
-  echo 'export PYENV_ROOT="$HOME/.pyenv"' >> "$shell_rc"
-  echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> "$shell_rc"
-  echo "eval \"\$(pyenv init - $shell_type)\"" >> "$shell_rc"
-  echo 'eval "$(pyenv virtualenv-init -)"' >> "$shell_rc"
+  {
+  echo
+  echo "# Set up Pyenv"
+  echo 'export PYENV_ROOT="$HOME/.pyenv"'
+  echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
+  echo "eval \"\$(pyenv init - $shell_type)\""
+  echo 'eval "$(pyenv virtualenv-init -)"'
+  } >> "$shell_rc"
 fi
 # run the above locally to use in this shell
 export PYENV_ROOT="$HOME/.pyenv"

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -28,20 +28,20 @@ ruff
 ipython
 EOF
 
-if ! grep -qc 'pyenv init' "$shell_rc" ; then
+if ! grep -qc 'pyenv init' "$shell_rc"; then
   echo "## Adding pyenv to $shell_rc ##"
   {
-  echo
-  echo "# Set up Pyenv"
-  echo 'export PYENV_ROOT="$HOME/.pyenv"'
-  echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
-  echo "eval \"\$(pyenv init - $shell_type)\""
-  echo 'eval "$(pyenv virtualenv-init -)"'
+    echo
+    echo "# Set up Pyenv"
+    echo 'export PYENV_ROOT="$HOME/.pyenv"'
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
+    echo "eval \"\$(pyenv init - $shell_type)\""
+    echo 'eval "$(pyenv virtualenv-init -)"'
   } >> "$shell_rc"
 fi
 # run the above locally to use in this shell
 export PYENV_ROOT="$HOME/.pyenv"
-command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+command -v pyenv > /dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 
@@ -63,7 +63,7 @@ python3 -m pip install --user pipx
 pipx ensurepath
 
 # add autocompletion for pipx
-if ! grep -qc 'pipx' "$shell_rc" ; then
+if ! grep -qc 'pipx' "$shell_rc"; then
   echo 'eval "$(register-python-argcomplete pipx)"' >> "$shell_rc"
 fi
 

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -12,51 +12,55 @@ echo
 # we still install pyenv, though I now tend to use `uv` for python version
 # management too. Pyenv is still handy to have an updated global version
 # available.
-curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
-# install a couple of plugins...
-git clone https://github.com/yyuu/pyenv-pip-migrate.git ~/.pyenv/plugins/pyenv-pip-migrate
-git clone https://github.com/yyuu/pyenv-ccache.git ~/.pyenv/plugins/pyenv-ccache
-git clone https://github.com/jawshooah/pyenv-default-packages.git ~/.pyenv/plugins/pyenv-default-packages
+if run_downloaded_installer pyenv \
+  https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer \
+  pyenv-installer.sh bash; then
+  # install a couple of plugins...
+  git clone https://github.com/yyuu/pyenv-pip-migrate.git ~/.pyenv/plugins/pyenv-pip-migrate
+  git clone https://github.com/yyuu/pyenv-ccache.git ~/.pyenv/plugins/pyenv-ccache
+  git clone https://github.com/jawshooah/pyenv-default-packages.git ~/.pyenv/plugins/pyenv-default-packages
 
-# Set up a default-packages file for python libraries to install with each new
-# python or venv ... for now, just a few that allow my vscode settings to work
-# easier. Will probably deprecate this later, as I now use 'Poetry' for
-# dependency management.
-cat <<- EOF > ~/.pyenv/default-packages
+  # Set up a default-packages file for python libraries to install with each new
+  # python or venv ... for now, just a few that allow my vscode settings to work
+  # easier. Will probably deprecate this later, as I now use 'Poetry' for
+  # dependency management.
+  cat <<- EOF > ~/.pyenv/default-packages
 wheel
 ruff
 ipython
 EOF
 
-if ! grep -q 'pyenv init' "$shell_rc"; then
-  echo "## Adding pyenv to $shell_rc ##"
-  {
-    echo
-    echo "# Set up Pyenv"
-    echo 'export PYENV_ROOT="$HOME/.pyenv"'
-    echo 'command -v pyenv > /dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
-    echo "eval \"\$(pyenv init - $shell_type)\""
-    echo 'eval "$(pyenv virtualenv-init -)"'
-  } >> "$shell_rc"
-fi
-# run the above locally to use in this shell
-export PYENV_ROOT="$HOME/.pyenv"
-command -v pyenv > /dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
+  if ! grep -q 'pyenv init' "$shell_rc"; then
+    echo "## Adding pyenv to $shell_rc ##"
+    {
+      echo
+      echo "# Set up Pyenv"
+      echo 'export PYENV_ROOT="$HOME/.pyenv"'
+      echo 'command -v pyenv > /dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
+      echo "eval \"\$(pyenv init - $shell_type)\""
+      echo 'eval "$(pyenv virtualenv-init -)"'
+    } >> "$shell_rc"
+  fi
+  # run the above locally to use in this shell
+  export PYENV_ROOT="$HOME/.pyenv"
+  command -v pyenv > /dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
 
-pyenv install 3.14
-pyenv global 3.14
-# now update 'pip' to the latest version ...
-python3 -m pip install --upgrade pip
+  pyenv install 3.14
+  pyenv global 3.14
+  # now update 'pip' to the latest version ...
+  python3 -m pip install --upgrade pip
+fi
 
 # Install 'poetry' for packaging and dependency management.
-curl -sSL https://install.python-poetry.org | python3 -
-
-# Tell poetry to create the venvs in the local project folder not global
-# This is optional, but I find it helps to cut down on the amount of random
-# venvs on your system, and keeps things obviously grouped.
-poetry config virtualenvs.in-project true
+if run_downloaded_installer poetry https://install.python-poetry.org \
+  poetry-installer.py python3; then
+  # Tell poetry to create the venvs in the local project folder not global
+  # This is optional, but I find it helps to cut down on the amount of random
+  # venvs on your system, and keeps things obviously grouped.
+  poetry config virtualenvs.in-project true
+fi
 
 # install pipx for managing global python packages
 python3 -m pip install --user pipx
@@ -72,12 +76,13 @@ eval "$(register-python-argcomplete pipx)"
 
 # install 'uv' for python project and version management (replaces poetry). This
 # can also replace 'pipx' but we'll keep both available for now.
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# prepare the uv config file if it does not exist
-mkdir -p "$HOME/.config/uv"
-touch "$HOME/.config/uv/uv.toml"
-if ! grep -q 'python-preference' "$HOME/.config/uv/uv.toml"; then
-  # only use uv's own python versions, not any pyenv
-  echo 'python-preference="only-managed"' >> "$HOME/.config/uv/uv.toml"
+if run_downloaded_installer uv https://astral.sh/uv/install.sh \
+  uv-installer.sh sh; then
+  # prepare the uv config file if it does not exist
+  mkdir -p "$HOME/.config/uv"
+  touch "$HOME/.config/uv/uv.toml"
+  if ! grep -q 'python-preference' "$HOME/.config/uv/uv.toml"; then
+    # only use uv's own python versions, not any pyenv
+    echo 'python-preference="only-managed"' >> "$HOME/.config/uv/uv.toml"
+  fi
 fi

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -28,13 +28,13 @@ ruff
 ipython
 EOF
 
-if ! grep -qc 'pyenv init' "$shell_rc"; then
+if ! grep -q 'pyenv init' "$shell_rc"; then
   echo "## Adding pyenv to $shell_rc ##"
   {
     echo
     echo "# Set up Pyenv"
     echo 'export PYENV_ROOT="$HOME/.pyenv"'
-    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
+    echo 'command -v pyenv > /dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
     echo "eval \"\$(pyenv init - $shell_type)\""
     echo 'eval "$(pyenv virtualenv-init -)"'
   } >> "$shell_rc"
@@ -63,7 +63,7 @@ python3 -m pip install --user pipx
 pipx ensurepath
 
 # add autocompletion for pipx
-if ! grep -qc 'pipx' "$shell_rc"; then
+if ! grep -q 'pipx' "$shell_rc"; then
   echo 'eval "$(register-python-argcomplete pipx)"' >> "$shell_rc"
 fi
 
@@ -77,7 +77,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # prepare the uv config file if it does not exist
 mkdir -p "$HOME/.config/uv"
 touch "$HOME/.config/uv/uv.toml"
-if ! grep -qc 'python-preference' "$HOME/.config/uv/uv.toml"; then
+if ! grep -q 'python-preference' "$HOME/.config/uv/uv.toml"; then
   # only use uv's own python versions, not any pyenv
   echo 'python-preference="only-managed"' >> "$HOME/.config/uv/uv.toml"
 fi

--- a/modules/python.sh
+++ b/modules/python.sh
@@ -48,13 +48,6 @@ pyenv global 3.14
 # now update 'pip' to the latest version ...
 python3 -m pip install --upgrade pip
 
-# add the .local/bin to the path if it isn't already there...
-if ! grep -qc '/.local/bin' "$shell_rc" ; then
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$shell_rc"
-fi
-# run the above locally to use in this shell
-export PATH="$HOME/.local/bin:$PATH"
-
 # Install 'poetry' for packaging and dependency management.
 curl -sSL https://install.python-poetry.org | python3 -
 

--- a/modules/qemu-kvm.sh
+++ b/modules/qemu-kvm.sh
@@ -2,11 +2,11 @@
 # qemu-kvm.sh
 # Install support files needed to work with KVM virtual machines using libvirt
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Qemu and support files.                          |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 sudo DEBIAN_FRONTEND=noninteractive apt install qemu-kvm libvirt-clients libvirt-daemon-system bridge-utils virt-manager ovmf cpu-checker
 

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -10,10 +10,6 @@ echo
 
 export PATH="$HOME/.rbenv/bin:$PATH"
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
-# install dynamic bash extension
-(
-  cd "$HOME/.rbenv" && src/configure && make -C src
-)
 # add the rbenv setup to our profile, only if it is not already there
 if ! grep -q 'rbenv init' "$shell_rc"; then
   echo "## Adding rbenv to $shell_rc ##"
@@ -23,6 +19,21 @@ if ! grep -q 'rbenv init' "$shell_rc"; then
     echo 'export PATH="$HOME/.rbenv/bin:$PATH"'
     echo "eval \"\$(rbenv init - $shell_type)\""
   } >> "$shell_rc"
+fi
+if [ "$shell_type" = "zsh" ] &&
+  ! grep -Fq '.rbenv/completions' "$shell_rc"; then
+  cat << 'EOF' >> "$shell_rc"
+
+# Load rbenv completions
+fpath=("$HOME/.rbenv/completions" $fpath)
+if (( ${+functions[compdef]} )); then
+  autoload -Uz _rbenv
+  compdef _rbenv rbenv
+else
+  autoload -Uz compinit
+  compinit
+fi
+EOF
 fi
 # run the above command locally so we can get rbenv to work on this provisioning shell
 eval "$(rbenv init - bash)"

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -11,7 +11,7 @@ echo
 if ! run_downloaded_installer rbenv \
   https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer \
   rbenv-installer.sh bash; then
-  return
+  return 1
 fi
 export PATH="$HOME/.rbenv/bin:$PATH"
 # add the rbenv setup to our profile, only if it is not already there

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -15,10 +15,12 @@ cd ~/.rbenv && src/configure && make -C src
 # add the rbenv setup to our profile, only if it is not already there
 if ! grep -qc 'rbenv init' "$shell_rc" ; then
   echo "## Adding rbenv to $shell_rc ##"
-  echo >> "$shell_rc"
-  echo "# Set up Rbenv" >> "$shell_rc"
-  echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> "$shell_rc"
-  echo "eval \"\$(rbenv init - $shell_type)\"" >> "$shell_rc"
+  {
+  echo
+  echo "# Set up Rbenv"
+  echo 'export PATH="$HOME/.rbenv/bin:$PATH"'
+  echo "eval \"\$(rbenv init - $shell_type)\""
+  } >> "$shell_rc"
 fi
 # run the above command locally so we can get rbenv to work on this provisioning shell
 eval "$(rbenv init - bash)"
@@ -43,13 +45,13 @@ echo "gem: --no-document" > ~/.gemrc
 # install the latest ruby 3.x version and set as default, also the new 4.x branch,
 # but NOT as default
 rbenv install 3.4.9
-rbenv install 4.0.4
+rbenv install 4.0.6
 rbenv global 3.4.9
 # we need to erase 2 files temporarily (they will be regenerated) otherwise the
 # installation will pause for overwrite confirmation These are the 'ri' and
 # 'rdoc' scripts
-rm ~/.rbenv/versions/3.4.9/bin/rdoc
-rm ~/.rbenv/versions/3.4.9/bin/ri
+rm ~/.rbenv/versions/3.4.10/bin/rdoc
+rm ~/.rbenv/versions/3.4.10/bin/ri
 # now update RubyGems and the default gems
 gem update --system
 gem update

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -8,7 +8,11 @@ echo "| Installing Ruby 3 and 4                                     |"
 echo "---------------------------------------------------------------"
 echo
 
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+if ! run_downloaded_installer rbenv \
+  https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer \
+  rbenv-installer.sh bash; then
+  return
+fi
 export PATH="$HOME/.rbenv/bin:$PATH"
 # add the rbenv setup to our profile, only if it is not already there
 if ! grep -q 'rbenv init' "$shell_rc"; then

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -13,13 +13,13 @@ curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer
 # install dynamic bash extension
 cd ~/.rbenv && src/configure && make -C src
 # add the rbenv setup to our profile, only if it is not already there
-if ! grep -qc 'rbenv init' "$shell_rc" ; then
+if ! grep -qc 'rbenv init' "$shell_rc"; then
   echo "## Adding rbenv to $shell_rc ##"
   {
-  echo
-  echo "# Set up Rbenv"
-  echo 'export PATH="$HOME/.rbenv/bin:$PATH"'
-  echo "eval \"\$(rbenv init - $shell_type)\""
+    echo
+    echo "# Set up Rbenv"
+    echo 'export PATH="$HOME/.rbenv/bin:$PATH"'
+    echo "eval \"\$(rbenv init - $shell_type)\""
   } >> "$shell_rc"
 fi
 # run the above command locally so we can get rbenv to work on this provisioning shell

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -4,20 +4,19 @@
 
 echo
 echo "---------------------------------------------------------------"
-echo "| Installing Ruby 3.                                          |"
+echo "| Installing Ruby 3 and 4                                     |"
 echo "---------------------------------------------------------------"
 echo
 
-export PATH="$HOME/.rbenv/bin:$PATH"
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+export PATH="$HOME/.rbenv/bin:$PATH"
 # add the rbenv setup to our profile, only if it is not already there
 if ! grep -q 'rbenv init' "$shell_rc"; then
   echo "## Adding rbenv to $shell_rc ##"
   {
     echo
     echo "# Set up Rbenv"
-    echo 'export PATH="$HOME/.rbenv/bin:$PATH"'
-    echo "eval \"\$(rbenv init - $shell_type)\""
+    printf 'eval "$("$HOME/.rbenv/bin/rbenv" init - %s)"\n' "$shell_type"
   } >> "$shell_rc"
 fi
 if [ "$shell_type" = "zsh" ] &&

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -11,7 +11,9 @@ echo
 export PATH="$HOME/.rbenv/bin:$PATH"
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
 # install dynamic bash extension
-cd ~/.rbenv && src/configure && make -C src
+(
+  cd "$HOME/.rbenv" && src/configure && make -C src
+)
 # add the rbenv setup to our profile, only if it is not already there
 if ! grep -qc 'rbenv init' "$shell_rc"; then
   echo "## Adding rbenv to $shell_rc ##"
@@ -44,9 +46,9 @@ echo "gem: --no-document" > ~/.gemrc
 
 # install the latest ruby 3.x version and set as default, also the new 4.x branch,
 # but NOT as default
-rbenv install 3.4.9
+rbenv install 3.4.10
 rbenv install 4.0.6
-rbenv global 3.4.9
+rbenv global 3.4.10
 # we need to erase 2 files temporarily (they will be regenerated) otherwise the
 # installation will pause for overwrite confirmation These are the 'ri' and
 # 'rdoc' scripts

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -2,11 +2,11 @@
 # ruby.sh
 # install ruby via the 'rbenv' system and some supporting plugins.
 
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Ruby 3.                                          |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 export PATH="$HOME/.rbenv/bin:$PATH"
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -15,7 +15,7 @@ curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer
   cd "$HOME/.rbenv" && src/configure && make -C src
 )
 # add the rbenv setup to our profile, only if it is not already there
-if ! grep -qc 'rbenv init' "$shell_rc"; then
+if ! grep -q 'rbenv init' "$shell_rc"; then
   echo "## Adding rbenv to $shell_rc ##"
   {
     echo

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -16,7 +16,8 @@ export PATH="$HOME/.cargo/bin:$PATH"
 rustup component add clippy
 rustup component add rustfmt
 
-cargo install cargo-edit # upgrade dependencies from the CLI
-cargo install cargo-make # useful task runner
+# add 'cargo-binstall' to speed up later installs.
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-cargo install bob-nvim # neovim version manager
+cargo bininstall cargo-edit --no-confirm # upgrade dependencies from the CLI
+cargo bininstall cargo-make --no-confirm # useful task runner

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # rust.sh Install the latest version of 'Rust' using 'Rustup'.
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing Rust and related tools.                          |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -8,7 +8,7 @@ echo
 
 if ! run_downloaded_installer rustup https://sh.rustup.rs \
   rustup-installer.sh sh -y; then
-  return
+  return 1
 fi
 
 # add the .cargo/bin to the path for this shell in case we want to use it

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -19,5 +19,5 @@ rustup component add rustfmt
 # add 'cargo-binstall' to speed up later installs.
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-cargo bininstall cargo-edit --no-confirm # upgrade dependencies from the CLI
-cargo bininstall cargo-make --no-confirm # useful task runner
+cargo binstall cargo-edit --no-confirm # upgrade dependencies from the CLI
+cargo binstall cargo-make --no-confirm # useful task runner

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -6,7 +6,10 @@ echo "| Installing Rust and related tools.                          |"
 echo "---------------------------------------------------------------"
 echo
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+if ! run_downloaded_installer rustup https://sh.rustup.rs \
+  rustup-installer.sh sh -y; then
+  return
+fi
 
 # add the .cargo/bin to the path for this shell in case we want to use it
 # later in the script.

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -17,7 +17,14 @@ rustup component add clippy
 rustup component add rustfmt
 
 # add 'cargo-binstall' to speed up later installs.
-curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+cargo_binstall_tmp=$(mktemp -t "cargo-binstall.XXXXXX")
+if ! curl -L --proto '=https' --tlsv1.2 -sSf \
+  https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
+  -o "$cargo_binstall_tmp" ||
+  ! bash "$cargo_binstall_tmp"; then
+  record_failed_install cargo-binstall
+fi
+rm -f -- "$cargo_binstall_tmp"
 
-cargo binstall cargo-edit --no-confirm # upgrade dependencies from the CLI
-cargo binstall cargo-make --no-confirm # useful task runner
+install_with_cargo_binstall cargo-edit # upgrade dependencies from the CLI
+install_with_cargo_binstall cargo-make # useful task runner

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -20,12 +20,10 @@ rustup component add clippy
 rustup component add rustfmt
 
 # add 'cargo-binstall' to speed up later installs.
-cargo_binstall_tmp="$install_tmp_dir/cargo-binstall-installer.sh"
-if ! curl -L --proto '=https' --tlsv1.2 -sSf \
+if ! run_downloaded_installer cargo-binstall \
   https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
-  -o "$cargo_binstall_tmp" ||
-  ! (cd "$install_tmp_dir" && bash "$cargo_binstall_tmp"); then
-  record_failed_install cargo-binstall
+  cargo-binstall-installer.sh bash; then
+  :
 fi
 
 install_with_cargo_binstall cargo-edit # upgrade dependencies from the CLI

--- a/modules/rust.sh
+++ b/modules/rust.sh
@@ -17,14 +17,13 @@ rustup component add clippy
 rustup component add rustfmt
 
 # add 'cargo-binstall' to speed up later installs.
-cargo_binstall_tmp=$(mktemp -t "cargo-binstall.XXXXXX")
+cargo_binstall_tmp="$install_tmp_dir/cargo-binstall-installer.sh"
 if ! curl -L --proto '=https' --tlsv1.2 -sSf \
   https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
   -o "$cargo_binstall_tmp" ||
-  ! bash "$cargo_binstall_tmp"; then
+  ! (cd "$install_tmp_dir" && bash "$cargo_binstall_tmp"); then
   record_failed_install cargo-binstall
 fi
-rm -f -- "$cargo_binstall_tmp"
 
 install_with_cargo_binstall cargo-edit # upgrade dependencies from the CLI
 install_with_cargo_binstall cargo-make # useful task runner

--- a/modules/updates.sh
+++ b/modules/updates.sh
@@ -17,10 +17,9 @@ echo "| for the next step.                                          |"
 echo "---------------------------------------------------------------"
 echo
 sudo DEBIAN_FRONTEND=noninteractive apt install -y dialog apt-utils \
-                        software-properties-common curl wget \
-                        ca-certificates gnupg gnupg-agent apt-transport-https \
-                        bash-completion cmake pkg-config iputils-ping lsb-release
-
+  software-properties-common curl wget \
+  ca-certificates gnupg gnupg-agent apt-transport-https \
+  bash-completion cmake pkg-config iputils-ping lsb-release
 
 # Add some third-party PPA repos to give us more recent versions of assorted
 # software...
@@ -62,7 +61,7 @@ echo \
 wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
 sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
 echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
 # update then upgrade...
 echo

--- a/modules/updates.sh
+++ b/modules/updates.sh
@@ -10,12 +10,12 @@ export DEBIAN_FRONTEND=noninteractive
 sudo apt update
 
 # some minimal versions of Ubuntu lack these...
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Installing some packages that are often missing, but needed |"
 echo "| for the next step.                                          |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 sudo DEBIAN_FRONTEND=noninteractive apt install -y dialog apt-utils \
                         software-properties-common curl wget \
                         ca-certificates gnupg gnupg-agent apt-transport-https \
@@ -65,10 +65,10 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 
 # update then upgrade...
-echo ""
+echo
 echo "---------------------------------------------------------------"
 echo "| Updating all the currently installed Packages.              |"
 echo "---------------------------------------------------------------"
-echo ""
+echo
 sudo apt update
 sudo DEBIAN_FRONTEND=noninteractive apt -y full-upgrade

--- a/modules/wsl.sh
+++ b/modules/wsl.sh
@@ -7,10 +7,10 @@
 distro=$(grep -h 'DISTRIB_ID' /etc/*-release | awk -F= '{print $2}')
 
 if [ "$distro" == "Ubuntu" ]; then
-  echo ""
+  echo
   echo "---------------------------------------------------------------"
   echo "| Installing WSL specific libraries for Ubuntu.               |"
   echo "---------------------------------------------------------------"
-  echo ""
+  echo
   sudo apt install -y ubuntu-wsl
 fi

--- a/scripts/check-shell.sh
+++ b/scripts/check-shell.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 bash -n comfy-chair.sh modules/*.sh docker-shell.sh support/docker-entrypoint.sh
 
 if command -v shellcheck > /dev/null; then
-  shellcheck -ax comfy-chair.sh docker-shell.sh support/docker-entrypoint.sh
+  shellcheck -ax --severity=warning \
+    comfy-chair.sh docker-shell.sh support/docker-entrypoint.sh
 else
   echo "shellcheck is not installed; skipping ShellCheck."
   echo "On Ubuntu, install it with: sudo apt install shellcheck"

--- a/scripts/check-shell.sh
+++ b/scripts/check-shell.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 bash -n comfy-chair.sh modules/*.sh docker-shell.sh support/docker-entrypoint.sh
 
-if command -v shellcheck >/dev/null; then
+if command -v shellcheck > /dev/null; then
   shellcheck -ax comfy-chair.sh docker-shell.sh support/docker-entrypoint.sh
 else
   echo "shellcheck is not installed; skipping ShellCheck."

--- a/scripts/check-shell.sh
+++ b/scripts/check-shell.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 bash -n comfy-chair.sh modules/*.sh docker-shell.sh support/docker-entrypoint.sh
 
 if command -v shellcheck >/dev/null; then
-  shellcheck -x comfy-chair.sh docker-shell.sh support/docker-entrypoint.sh
+  shellcheck -ax comfy-chair.sh docker-shell.sh support/docker-entrypoint.sh
 else
   echo "shellcheck is not installed; skipping ShellCheck."
   echo "On Ubuntu, install it with: sudo apt install shellcheck"

--- a/support/docker-entrypoint.sh
+++ b/support/docker-entrypoint.sh
@@ -19,11 +19,11 @@ while true; do
   read -r -p "> " choice
 
   case "$choice" in
-    1|bash|Bash|BASH)
+    1 | bash | Bash | BASH)
       export SHELL=/bin/bash
       exec /bin/bash -l
       ;;
-    2|zsh|Zsh|ZSH)
+    2 | zsh | Zsh | ZSH)
       export SHELL=/bin/zsh
       exec /bin/zsh -l
       ;;


### PR DESCRIPTION
## Summary

- Expands the bootstrapper with Yazi, Atuin, delta, hyperfine, xh, Watchexec,
  Tokei, Television, ShellCheck, shfmt, jq, yq, lsplus, dust, and duf.
- Adds shell integration for Yazi and Atuin, generates Bash and zsh completions
  for user-installed tools, provides architecture-aware binary downloads, and
  uses cargo-binstall for supported Rust tools.
- Centralizes the user-local binary path and updates the NVM, Perl, and Ruby
  toolchain versions included by the bootstrapper.
- Improves shell lint coverage, applies consistent shfmt formatting, and documents
  the installed development tools in the README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Better CPU/architecture-aware provisioning for downloaded tools.
  - Automatic shell completion generation for installed user tools.
  - Improved Rust tooling setup by bootstrapping `cargo-binstall` to speed installs.
- **Bug Fixes**
  - More reliable shell startup configuration and `PATH` updates (including ensuring startup files exist).
  - Optional component install failures are now tracked and summarised, with improved repeat-run safety.
- **Documentation**
  - README now clarifies install behaviour (latest stable at provision time, not version-pinned, not bit-for-bit reproducible).
  - TODO updated with a Docker test environment plan (including a `--keep` option).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->